### PR TITLE
refactor: simplify route handling and improve URL consistency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,10 @@
   - Use https://docs.rs/tower-http/latest/tower_http/trace/index.html
   - https://docs.rs/tracing/latest/tracing/
 - Change name: libaxum to oauth2_passkey_axum
+- Fix: add O2P_ROUTE_PREFIX to fetch('/summary/user-info', {
+- Completely separate create_account function from add_to_existing_user function to avoid the case where new user is created even though user is already logged in.
+
+
 
 ## Half Done
 

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,6 @@
   - Use https://docs.rs/tower-http/latest/tower_http/trace/index.html
   - https://docs.rs/tracing/latest/tracing/
 - Change name: libaxum to oauth2_passkey_axum
-- Fix: add O2P_ROUTE_PREFIX to fetch('/summary/user-info', {
 - Completely separate create_account function from add_to_existing_user function to avoid the case where new user is created even though user is already logged in.
 
 
@@ -69,7 +68,7 @@
   - I want to change it to O2P_ROUTE_PREFIX/passkey and O2P_ROUTE_PREFIX/oauth2 respectively. By doing so we only need to nest single tree in the application. The summary endpoint can be also nested in the same tree freeing from necessity of explicitly mounting it in the application.
 
 - Middleware based page protection i.e. create a likes of is_authorized middleware.
-
+- Fix: add O2P_ROUTE_PREFIX to "fetch('/summary/user-info', {"
 
 ## Memo
 

--- a/demo-integration/src/handlers.rs
+++ b/demo-integration/src/handlers.rs
@@ -4,7 +4,7 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Redirect, Response},
 };
-use oauth2_passkey::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
+use oauth2_passkey::O2P_ROUTE_PREFIX;
 
 // User extracted from session by libaxum crate
 use oauth2_passkey_axum::AuthUser as User;
@@ -14,36 +14,34 @@ use oauth2_passkey_axum::AuthUser as User;
 struct IndexTemplateUser<'a> {
     // user: User,
     message: &'a str,
-    oauth_route_prefix: &'a str,
-    passkey_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 #[derive(Template)]
 #[template(path = "index_anon.j2")]
 struct IndexTemplateAnon<'a> {
     message: &'a str,
-    oauth_route_prefix: &'a str,
-    passkey_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 #[derive(Template)]
 #[template(path = "protected.j2")]
 struct ProtectedTemplate<'a> {
     user: User,
-    oauth_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 #[derive(Template)]
 #[template(path = "p1.j2")]
 struct P1Template<'a> {
-    oauth_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 #[derive(Template)]
 #[template(path = "p2.j2")]
 struct P2Template<'a> {
     user: User,
-    oauth_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, String)> {
@@ -51,14 +49,11 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
         Some(u) => {
             let message = format!("Hey {}!", u.account);
             // Create the route strings first so they live long enough
-            let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-            let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
 
             let template = IndexTemplateUser {
                 // user: u.clone(),
                 message: &message,
-                oauth_route_prefix: &oauth_route,
-                passkey_route_prefix: &passkey_route,
+                o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
             };
             let _html = Html(
                 template
@@ -66,18 +61,15 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
             );
             // Ok(html.into_response())
-            let summary_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), SUMMARY_SUB_ROUTE);
+            let summary_route = format!("{}/summary", O2P_ROUTE_PREFIX.as_str());
             Ok(Redirect::to(&summary_route).into_response())
         }
         None => {
             // Create the route strings first so they live long enough
-            let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-            let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
 
             let template = IndexTemplateAnon {
                 message: "Passkey/OAuth2 integration demo!",
-                oauth_route_prefix: &oauth_route,
-                passkey_route_prefix: &passkey_route,
+                o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
             };
             let html = Html(
                 template
@@ -90,12 +82,9 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
 }
 
 pub(crate) async fn protected(user: User) -> Result<Html<String>, (StatusCode, String)> {
-    // Create the route string first so it lives long enough
-    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-
     let template = ProtectedTemplate {
         user,
-        oauth_route_prefix: &oauth_route,
+        o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
     };
     let html = Html(
         template
@@ -106,10 +95,8 @@ pub(crate) async fn protected(user: User) -> Result<Html<String>, (StatusCode, S
 }
 
 pub(crate) async fn p1() -> Result<Html<String>, (StatusCode, String)> {
-    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-
     let template = P1Template {
-        oauth_route_prefix: &oauth_route,
+        o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
     };
     let html = Html(
         template
@@ -123,12 +110,10 @@ pub(crate) async fn p2(
     // Extract user from extension inserted by is_authenticated_with_user middleware
     Extension(user): Extension<User>,
 ) -> Result<Html<String>, (StatusCode, String)> {
-    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-
     tracing::debug!("User: {:?}", user);
     let template = P2Template {
         user,
-        oauth_route_prefix: &oauth_route,
+        o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
     };
     let html = Html(
         template
@@ -136,4 +121,17 @@ pub(crate) async fn p2(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
     );
     Ok(html)
+}
+
+// Example handler that will redirect to a page defined by AuthRedirect when user is not authenticated
+pub(crate) async fn p3(user: User) -> impl IntoResponse {
+    Html(format!("Hey {}!", user.account))
+}
+
+// Example handler that will show a message when user is not authenticated
+pub(crate) async fn p4(user: Option<User>) -> impl IntoResponse {
+    match user {
+        Some(u) => Html(format!("Hey {}!", u.account)),
+        None => Html("Not Authenticated!".to_string()),
+    }
 }

--- a/demo-integration/src/main.rs
+++ b/demo-integration/src/main.rs
@@ -10,7 +10,7 @@ use oauth2_passkey_axum::{
     oauth2_passkey_router, passkey_well_known_router,
 };
 
-use handlers::{index, p1, p2, protected};
+use handlers::{index, p1, p2, p3, p4, protected};
 use server::{Ports, spawn_http_server, spawn_https_server};
 
 #[tokio::main]
@@ -90,6 +90,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/p2",
             get(p2).route_layer(from_fn(is_authenticated_with_user)),
         )
+        .route("/p3", get(p3))
+        .route("/p4", get(p4))
         .nest(O2P_ROUTE_PREFIX.as_str(), oauth2_passkey_router())
         .nest("/.well-known", passkey_well_known_router()); // Mount the WebAuthn well-known endpoint at root level
 

--- a/demo-integration/templates/index_anon.j2
+++ b/demo-integration/templates/index_anon.j2
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Index Page</title>
 
-    <script src="{{oauth_route_prefix}}/oauth2.js"></script>
-    <script src="{{passkey_route_prefix}}/passkey.js"></script>
+    <script src="{{o2p_route_prefix}}/oauth2/oauth2.js"></script>
+    <script src="{{o2p_route_prefix}}/passkey/passkey.js"></script>
     {# <!--Conditional UI does not work as we expect it to-->
     <!--<script src="{{passkey_route_prefix}}/conditional_ui.js"></script>-->
     <!--
@@ -31,8 +31,7 @@
     --> #}
     <script>
         const oauth2 = initOAuth2Popup();
-        const OAUTH_ROUTE_PREFIX = '{{oauth_route_prefix}}';
-        const PASSKEY_ROUTE_PREFIX = '{{passkey_route_prefix}}';
+        const O2P_ROUTE_PREFIX = '{{o2p_route_prefix}}';
     </script>
 
 </head>
@@ -56,7 +55,7 @@
             Create User
         </button>
         <button onclick="startAuthentication(false)">Sign in</button>
-        or <a href="{{passkey_route_prefix}}/conditional_ui">try conditional UI</a>
+        or <a href="{{o2p_route_prefix}}/passkey/conditional_ui">try conditional UI</a>
     </div>
 
     {# <!--Conditional UI does not work as we expect it to-->

--- a/demo-integration/templates/index_user.j2
+++ b/demo-integration/templates/index_user.j2
@@ -56,17 +56,16 @@
         <button onclick="Logout()">Logout</button>
         <script>
             function Logout() {
-                window.location.href = "{{oauth_route_prefix}}/logout";
+                window.location.href = "{{o2p_route_prefix}}/oauth2/logout";
             }
         </script>
     </div>
 
-    <script src="{{oauth_route_prefix}}/oauth2.js"></script>
-    <script src="{{passkey_route_prefix}}/passkey.js"></script>
+    <script src="{{o2p_route_prefix}}/oauth2/oauth2.js"></script>
+    <script src="{{o2p_route_prefix}}/passkey/passkey.js"></script>
     <script>
         const oauth2 = initOAuth2Popup();
-        const OAUTH_ROUTE_PREFIX = '{{oauth_route_prefix}}';
-        const PASSKEY_ROUTE_PREFIX = '{{passkey_route_prefix}}';
+        const O2P_ROUTE_PREFIX = '{{o2p_route_prefix}}';
     </script>
 
 </body>

--- a/demo-integration/templates/p1.j2
+++ b/demo-integration/templates/p1.j2
@@ -43,7 +43,7 @@
         </dl>
     </div>
 
-    <p><a href="{{ oauth_route_prefix }}/logout">Logout</a></p>
+    <p><a href="{{ o2p_route_prefix }}/oauth2/logout">Logout</a></p>
 </body>
 
 </html>

--- a/demo-integration/templates/p2.j2
+++ b/demo-integration/templates/p2.j2
@@ -43,7 +43,7 @@
         </dl>
     </div>
 
-    <p><a href="{{ oauth_route_prefix }}/logout">Logout</a></p>
+    <p><a href="{{ o2p_route_prefix }}/oauth2/logout">Logout</a></p>
 </body>
 
 </html>

--- a/demo-integration/templates/protected.j2
+++ b/demo-integration/templates/protected.j2
@@ -43,7 +43,7 @@
         </dl>
     </div>
 
-    <p><a href="{{ oauth_route_prefix }}/logout">Logout</a></p>
+    <p><a href="{{ o2p_route_prefix }}/oauth2/logout">Logout</a></p>
 </body>
 
 </html>

--- a/oauth2_passkey/src/config.rs
+++ b/oauth2_passkey/src/config.rs
@@ -8,21 +8,3 @@ use std::sync::LazyLock;
 /// Default: "/o2p"
 pub static O2P_ROUTE_PREFIX: LazyLock<String> =
     LazyLock::new(|| std::env::var("O2P_ROUTE_PREFIX").unwrap_or_else(|_| "/o2p".to_string()));
-
-/// Sub-route for OAuth2 endpoints
-///
-/// This will be mounted under O2P_ROUTE_PREFIX
-/// Full path: {O2P_ROUTE_PREFIX}/oauth2
-pub const OAUTH2_SUB_ROUTE: &str = "/oauth2";
-
-/// Sub-route for Passkey endpoints
-///
-/// This will be mounted under O2P_ROUTE_PREFIX
-/// Full path: {O2P_ROUTE_PREFIX}/passkey
-pub const PASSKEY_SUB_ROUTE: &str = "/passkey";
-
-/// Sub-route for Summary endpoints
-///
-/// This will be mounted under O2P_ROUTE_PREFIX
-/// Full path: {O2P_ROUTE_PREFIX}/summary
-pub const SUMMARY_SUB_ROUTE: &str = "/summary";

--- a/oauth2_passkey/src/lib.rs
+++ b/oauth2_passkey/src/lib.rs
@@ -30,7 +30,7 @@ pub use coordination::{
 };
 
 // Re-export the route prefixes
-pub use config::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
+pub use config::O2P_ROUTE_PREFIX;
 
 pub use oauth2::{AuthResponse, OAuth2Account, OAuth2Error, prepare_oauth2_auth_request};
 

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -1,4 +1,4 @@
-use crate::config::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE};
+use crate::config::O2P_ROUTE_PREFIX;
 use std::{env, sync::LazyLock};
 
 pub(crate) static OAUTH2_USERINFO_URL: &str = "https://www.googleapis.com/userinfo/v2/me";
@@ -57,10 +57,9 @@ pub(crate) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
 
 pub(crate) static OAUTH2_REDIRECT_URI: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "{}{}{}/authorized",
+        "{}{}/oauth2/authorized",
         env::var("ORIGIN").expect("Missing ORIGIN!"),
-        O2P_ROUTE_PREFIX.as_str(),
-        OAUTH2_SUB_ROUTE
+        O2P_ROUTE_PREFIX.as_str()
     )
 });
 

--- a/oauth2_passkey_axum/src/oauth2.rs
+++ b/oauth2_passkey_axum/src/oauth2.rs
@@ -11,9 +11,9 @@ use axum_extra::{TypedHeader, headers};
 use std::collections::HashMap;
 
 use oauth2_passkey::{
-    AuthResponse, O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, OAuth2Account, SessionUser,
-    delete_oauth2_account_core, get_authorized_core, list_accounts_core, post_authorized_core,
-    prepare_logout_response, prepare_oauth2_auth_request, verify_context_token_and_page,
+    AuthResponse, O2P_ROUTE_PREFIX, OAuth2Account, SessionUser, delete_oauth2_account_core,
+    get_authorized_core, list_accounts_core, post_authorized_core, prepare_logout_response,
+    prepare_oauth2_auth_request, verify_context_token_and_page,
 };
 
 use super::session::AuthUser;
@@ -113,9 +113,8 @@ pub async fn get_authorized(
     Ok((
         headers,
         Redirect::to(&format!(
-            "{}{}/popup_close?message={}",
+            "{}/oauth2/popup_close?message={}",
             O2P_ROUTE_PREFIX.as_str(),
-            OAUTH2_SUB_ROUTE,
             urlencoding::encode(&message)
         )),
     ))
@@ -141,9 +140,8 @@ pub async fn post_authorized(
     Ok((
         headers,
         Redirect::to(&format!(
-            "{}{}/popup_close?message={}",
+            "{}/oauth2/popup_close?message={}",
             O2P_ROUTE_PREFIX.as_str(),
-            OAUTH2_SUB_ROUTE,
             urlencoding::encode(&message)
         )),
     ))

--- a/oauth2_passkey_axum/src/passkey.rs
+++ b/oauth2_passkey_axum/src/passkey.rs
@@ -7,11 +7,11 @@ use axum::{
 use serde_json::Value;
 
 use oauth2_passkey::{
-    AuthenticationOptions, AuthenticatorResponse, O2P_ROUTE_PREFIX, PASSKEY_SUB_ROUTE,
-    PasskeyCredential, RegisterCredential, RegistrationOptions, RegistrationStartRequest,
-    SessionUser, delete_passkey_credential_core, get_related_origin_json,
-    handle_finish_authentication_core, handle_finish_registration_core,
-    handle_start_authentication_core, handle_start_registration_core, list_credentials_core,
+    AuthenticationOptions, AuthenticatorResponse, O2P_ROUTE_PREFIX, PasskeyCredential,
+    RegisterCredential, RegistrationOptions, RegistrationStartRequest, SessionUser,
+    delete_passkey_credential_core, get_related_origin_json, handle_finish_authentication_core,
+    handle_finish_registration_core, handle_start_authentication_core,
+    handle_start_registration_core, list_credentials_core,
 };
 
 use crate::IntoResponseError;
@@ -114,12 +114,12 @@ pub(crate) async fn serve_passkey_js() -> Response {
 #[derive(Template)]
 #[template(path = "conditional_ui.j2")]
 struct ConditionalUiTemplate<'a> {
-    passkey_route_prefix: &'a str,
+    o2p_route_prefix: &'a str,
 }
 
 pub(crate) async fn conditional_ui() -> impl IntoResponse {
     let template = ConditionalUiTemplate {
-        passkey_route_prefix: &format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE),
+        o2p_route_prefix: O2P_ROUTE_PREFIX.as_str(),
     };
     (StatusCode::OK, Html(template.render().unwrap_or_default())).into_response()
 }

--- a/oauth2_passkey_axum/src/router.rs
+++ b/oauth2_passkey_axum/src/router.rs
@@ -1,7 +1,6 @@
 //! Combined router for all authentication endpoints
 
 use axum::Router;
-use oauth2_passkey::{OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
 
 /// Create a combined router for all authentication endpoints
 ///
@@ -14,7 +13,7 @@ use oauth2_passkey::{OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
 /// This simplifies integration by requiring only a single router to be mounted in the application.
 pub fn oauth2_passkey_router() -> Router {
     Router::new()
-        .nest(OAUTH2_SUB_ROUTE, super::oauth2::router())
-        .nest(PASSKEY_SUB_ROUTE, super::passkey::router())
-        .nest(SUMMARY_SUB_ROUTE, super::summary::router())
+        .nest("/oauth2", super::oauth2::router())
+        .nest("/passkey", super::passkey::router())
+        .nest("/summary", super::summary::router())
 }

--- a/oauth2_passkey_axum/src/summary/handlers.rs
+++ b/oauth2_passkey_axum/src/summary/handlers.rs
@@ -9,8 +9,8 @@ use axum::{
 
 use oauth2_passkey::SessionUser;
 use oauth2_passkey::{
-    O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, delete_user_account, list_accounts_core,
-    list_credentials_core, update_user_account,
+    O2P_ROUTE_PREFIX, delete_user_account, list_accounts_core, list_credentials_core,
+    update_user_account,
 };
 
 use super::templates::{TemplateAccount, TemplateCredential, UserSummaryTemplate};
@@ -221,16 +221,13 @@ pub async fn user_summary(auth_user: AuthUser) -> Result<Html<String>, (StatusCo
 
     // Create template with all data
     // Create the route strings first
-    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
-    let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
 
     let template = UserSummaryTemplate::new(
         auth_user,
         passkey_credentials,
         oauth2_accounts,
         // Pass owned String values to the template
-        oauth_route,
-        passkey_route,
+        O2P_ROUTE_PREFIX.to_string(),
     );
 
     // Render the template

--- a/oauth2_passkey_axum/src/summary/templates.rs
+++ b/oauth2_passkey_axum/src/summary/templates.rs
@@ -36,8 +36,7 @@ pub struct UserSummaryTemplate {
     pub user: AuthUser,
     pub passkey_credentials: Vec<TemplateCredential>,
     pub oauth2_accounts: Vec<TemplateAccount>,
-    pub oauth_route_prefix: String,
-    pub passkey_route_prefix: String,
+    pub o2p_route_prefix: String,
     pub obfuscated_user_id: String,
 }
 
@@ -46,8 +45,7 @@ impl UserSummaryTemplate {
         user: AuthUser,
         passkey_credentials: Vec<TemplateCredential>,
         oauth2_accounts: Vec<TemplateAccount>,
-        oauth_route_prefix: String,
-        passkey_route_prefix: String,
+        o2p_route_prefix: String,
     ) -> Self {
         let obfuscated_user_id = obfuscate_user_id(&user.id);
 
@@ -55,8 +53,7 @@ impl UserSummaryTemplate {
             user,
             passkey_credentials,
             oauth2_accounts,
-            oauth_route_prefix,
-            passkey_route_prefix,
+            o2p_route_prefix,
             obfuscated_user_id,
         }
     }

--- a/oauth2_passkey_axum/static/conditional_ui.js
+++ b/oauth2_passkey_axum/static/conditional_ui.js
@@ -40,7 +40,7 @@ function base64URLToUint8Array(base64URL) {
 
     // Function to get fresh challenge from server
     async function getFreshChallenge() {
-        const response = await fetch(PASSKEY_ROUTE_PREFIX + '/auth/start', {
+        const response = await fetch(O2P_ROUTE_PREFIX + '/passkey/auth/start', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(null) // null for username-less auth
@@ -84,7 +84,7 @@ function base64URLToUint8Array(base64URL) {
 
             // If we get a credential, verify it
             if (credential) {
-                const authResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/auth/finish', {
+                const authResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/auth/finish', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/oauth2_passkey_axum/static/oauth2.js
+++ b/oauth2_passkey_axum/static/oauth2.js
@@ -5,13 +5,13 @@ function initOAuth2Popup() {
     function openPopup(mode=null, page_context=null) {
         if (mode === 'add_to_existing_user') {
             popupWindow = window.open(
-                `${OAUTH_ROUTE_PREFIX}/google?mode=${mode}&context=${page_context}`,
+                `${O2P_ROUTE_PREFIX}/oauth2/google?mode=${mode}&context=${page_context}`,
                 "PopupWindow",
                 "width=550,height=640,left=1000,top=200,resizable=yes,scrollbars=yes"
             );
         } else {
             popupWindow = window.open(
-                `${OAUTH_ROUTE_PREFIX}/google`,
+                `${O2P_ROUTE_PREFIX}/oauth2/google`,
                 "PopupWindow",
                 "width=550,height=640,left=1000,top=200,resizable=yes,scrollbars=yes"
             );

--- a/oauth2_passkey_axum/static/passkey.js
+++ b/oauth2_passkey_axum/static/passkey.js
@@ -27,7 +27,7 @@ async function startAuthentication(withUsername = false) {
     const authActions = document.getElementById("auth-actions");
 
     try {
-        const startResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/auth/start', {
+        const startResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/auth/start', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: "{}"
@@ -82,7 +82,7 @@ async function startAuthentication(withUsername = false) {
 
         console.log('Authentication response:', authResponse);
 
-        const verifyResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/auth/finish', {
+        const verifyResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/auth/finish', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(authResponse)
@@ -149,7 +149,7 @@ function showRegistrationModal(mode) {
     document.getElementById('reg-displayname').value = 'displayname';
 
     // Try to get current user info to pre-fill the form
-    fetch('/summary/user-info', {
+    fetch(O2P_ROUTE_PREFIX + '/summary/user-info', {
         method: 'GET',
         credentials: 'same-origin'
     })
@@ -207,7 +207,7 @@ async function startRegistration(mode, username = null, displayname = null) {
         };
 
         let startResponse;
-        startResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/register/start', {
+        startResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/register/start', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -257,7 +257,7 @@ async function startRegistration(mode, username = null, displayname = null) {
         // Use the single registration finish endpoint
         // The mode has already been verified at the start stage, and the page_context
         // is included in the credential for additional verification
-        const finishResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/register/finish', {
+        const finishResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/register/finish', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             // Include credentials to ensure cookies are sent with the request

--- a/oauth2_passkey_axum/templates/conditional_ui.j2
+++ b/oauth2_passkey_axum/templates/conditional_ui.j2
@@ -21,9 +21,9 @@
         </form>
     </div>
     <script>
-        const PASSKEY_ROUTE_PREFIX = '{{passkey_route_prefix}}';
+        const O2P_ROUTE_PREFIX = '{{o2p_route_prefix}}';
     </script>
-    <script src="{{passkey_route_prefix}}/conditional_ui.js"></script>
+    <script src="{{o2p_route_prefix}}/passkey/conditional_ui.js"></script>
 </body>
 
 </html>

--- a/oauth2_passkey_axum/templates/user_summary.j2
+++ b/oauth2_passkey_axum/templates/user_summary.j2
@@ -336,7 +336,7 @@
 
     <script>
         function Logout() {
-            window.location.href = "{{oauth_route_prefix}}/logout";
+            window.location.href = "{{o2p_route_prefix}}/oauth2/logout";
         }
 
         function toggleEditUserForm() {
@@ -357,7 +357,7 @@
             const account = document.getElementById('edit-account').value;
             const label = document.getElementById('edit-label').value;
 
-            fetch(`/summary/user/update`, {
+            fetch(`${O2P_ROUTE_PREFIX}/summary/user/update`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json'
@@ -397,7 +397,7 @@
             const accountName = "{{user.account}}";
             const userId = "{{user.id}}";
             if (confirm(`Are you sure you want to delete your account "${accountName}"? This action cannot be undone and will delete all your data including OAuth2 accounts and passkey credentials.`)) {
-                fetch(`/summary/user/delete`, {
+                fetch(`${O2P_ROUTE_PREFIX}/summary/user/delete`, {
                     method: 'DELETE',
                     headers: {
                         'Content-Type': 'application/json'
@@ -423,7 +423,7 @@
 
         function unlinkOAuth2Account(provider, providerUserId) {
             if (confirm('Are you sure you want to unlink this OAuth2 account?')) {
-                fetch(`${OAUTH_ROUTE_PREFIX}/accounts/${provider}/${providerUserId}`, {
+                fetch(`${O2P_ROUTE_PREFIX}/oauth2/accounts/${provider}/${providerUserId}`, {
                     method: 'DELETE',
                     headers: {
                         'Content-Type': 'application/json'
@@ -522,7 +522,7 @@
 
         function deletePasskeyCredential(credentialId, userHandle) {
             if (confirm('Are you sure you want to unlink this passkey credential?\n\nNote: While we will notify your browser about this deletion, you may need to manually remove the credential from your password manager if it doesn\'t disappear automatically.')) {
-                fetch(`${PASSKEY_ROUTE_PREFIX}/credentials/${credentialId}`, {
+                fetch(`${O2P_ROUTE_PREFIX}/passkey/credentials/${credentialId}`, {
                     method: 'DELETE',
                     headers: {
                         'Content-Type': 'application/json'
@@ -551,12 +551,11 @@
         }
     </script>
 
-    <script src="{{oauth_route_prefix}}/oauth2.js"></script>
-    <script src="{{passkey_route_prefix}}/passkey.js"></script>
+    <script src="{{o2p_route_prefix}}/oauth2/oauth2.js"></script>
+    <script src="{{o2p_route_prefix}}/passkey/passkey.js"></script>
     <script>
         const oauth2 = initOAuth2Popup();
-        const OAUTH_ROUTE_PREFIX = '{{oauth_route_prefix}}';
-        const PASSKEY_ROUTE_PREFIX = '{{passkey_route_prefix}}';
+        const O2P_ROUTE_PREFIX = '{{o2p_route_prefix}}';
     </script>
 
     <a href="/" class="back-link">← Back to Home</a>


### PR DESCRIPTION
- Remove hardcoded sub-route constants (OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE)
- Standardize on using O2P_ROUTE_PREFIX directly with explicit path segments
- Update all templates to use a single o2p_route_prefix variable
- Fix fetch URL in JavaScript files to include O2P_ROUTE_PREFIX
- Add example handlers p3 and p4 to demonstrate different authentication behaviors
- Fix issue where user-info endpoint was missing the route prefix