### PR TITLE
feat: enhance passkey AAGUID handling and improve documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,21 @@
 	- Can list and manage all users.
 - Does page context token verification work as csrf protection?
 	- Suppose the situation where a malicious user tries to let the admin give him admin privileges, or modify arbitrary user's account details.
+- Modify demo pages to include link to available pages.
+- Make demo-oauth2 and demo-passkey pages to implement login page and account summary page without relying on oauth2_passkey_axum's summary and login pages.
+- Add additional attributes to PasskeyCredentials.
+	- For example, authenticator_name, like Google Password Manager, App Password Manager, YubiKey etc.
+	- It is also possible that a user has multiple Google Password Managers with different Google accounts, so is possible for Apple Password Managers.
+	- A user may also have multiple YubiKeys.
+- Add AAGUID to PasskeyCredentials.
+	- or information about the authenticator retrieved using AAGUID
+	- need to figure out how to get an authenticator icon using AAGUID
+	- https://web.dev/articles/webauthn-aaguid
+	- https://fidoalliance.org/metadata/
+	- https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+	- https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/
+	- https://www.corbado.com/glossary/aaguid
+- Once we have AAGUID, we should fix the logic for deleting credentials in register.rs to use a combination of "AAGUID" and user_handle.
 
 ## Half Done
 

--- a/demo-passkey/Cargo.toml
+++ b/demo-passkey/Cargo.toml
@@ -12,7 +12,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 rustls = { workspace = true }
-oauth2_passkey_axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
-
 dotenv = { workspace = true }
 http = { workspace = true }
+
+oauth2_passkey_axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
+#oauth2_passkey_axum = { workspace = true }

--- a/dot.env.example
+++ b/dot.env.example
@@ -106,8 +106,9 @@ O2P_ROUTE_PREFIX='/o2p'
 #PASSKEY_USER_VERIFICATION='discouraged'
 
 # Default: true (Options: true, false)
-# Note: Most password managers don't allow multiple credentials with the same user handle for a single site.
-# Setting this to true works around this limitation but prevents cross-device credential syncing.
+# Note: Password managers typically allow only one credential per user identifier.
+# When false: Uses single user_handle for all credentials for a user (limits each user to have one credential per site)
+# When true: Generates unique user_handle per credential (allows each user to have multiple credentials per site)
 #PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=true
 
 ######################################

--- a/oauth2_passkey_axum/templates/login.j2
+++ b/oauth2_passkey_axum/templates/login.j2
@@ -25,7 +25,7 @@
     <div style="display: flex; gap: 10px; margin-top: 10px;">
         <button onclick="oauth2.openPopup('create_user')">Create User</button>
         <button onclick="oauth2.openPopup('login')">Sign in</button>
-        <button onclick="oauth2.openPopup('create_user_or_login')">Either is fine</button>
+        <button onclick="oauth2.openPopup('create_user_or_login')">Either way</button>
     </div>
 
     <div style="display: flex; gap: 10px; margin-top: 10px;">


### PR DESCRIPTION
This commit adds several improvements to the passkey system and documentation:

Passkey Enhancements:
- Add UUID parsing for AAGUID in attestation verification
- Convert binary AAGUID to hyphenated UUID string format for better readability
- Implement proper credential cleanup for non-unique user handles
- Add detailed logging for AAGUID values during verification

Documentation:
- Improve comments in register.rs with detailed function descriptions
- Clarify the behavior of user handle uniqueness in environment variables
- Update documentation to explain credential management strategies
- Add detailed roadmap items for future passkey enhancements

UI/UX:
- Improve button label text for better clarity ("Either way" vs "Either is fine")
- Clean up dependencies organization in demo-passkey/Cargo.toml

This implementation follows the principle of minimal and focused changes while providing better debugging information and preparing for future AAGUID-based credential management.