### PR TITLE
refactor(session): Simplify session management and configuration

### DIFF
--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -15,7 +15,7 @@ use crate::utils::header_set_cookie;
 use super::errors::CoordinationError;
 use super::user::gen_new_user_id;
 
-use crate::session::renew_session_header;
+use crate::session::new_session_header;
 
 pub async fn get_authorized_core(
     auth_response: &AuthResponse,
@@ -187,7 +187,7 @@ async fn process_oauth2_authorization(
         }
     };
 
-    let mut headers = renew_session_header(user_id).await?;
+    let mut headers = new_session_header(user_id).await?;
 
     let _ = header_set_cookie(
         &mut headers,

--- a/oauth2_passkey/src/coordination/passkey.rs
+++ b/oauth2_passkey/src/coordination/passkey.rs
@@ -11,7 +11,7 @@ use crate::passkey::{
     verify_session_then_finish_registration,
 };
 use crate::session::User as SessionUser;
-use crate::session::{renew_session_header, verify_context_token_and_page};
+use crate::session::{new_session_header, verify_context_token_and_page};
 use crate::userdb::{User, UserStore};
 
 use super::errors::CoordinationError;
@@ -119,7 +119,7 @@ pub async fn handle_finish_registration_core(
             match result {
                 Ok((message, stored_user_id)) => {
                     // Create session with the user_id
-                    let headers = renew_session_header(stored_user_id).await?;
+                    let headers = new_session_header(stored_user_id).await?;
 
                     Ok((headers, message))
                 }
@@ -210,7 +210,7 @@ pub async fn handle_finish_authentication_core(
     tracing::debug!("User ID: {:#?}", uid);
 
     // Create a session for the authenticated user
-    let headers = renew_session_header(uid.clone()).await?;
+    let headers = new_session_header(uid.clone()).await?;
 
     Ok((uid, name, headers))
 }

--- a/oauth2_passkey/src/session/config.rs
+++ b/oauth2_passkey/src/session/config.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::sync::LazyLock;
 
 pub static SESSION_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
@@ -16,4 +17,29 @@ pub static USER_CONTEXT_TOKEN_COOKIE: LazyLock<String> = LazyLock::new(|| {
     std::env::var("USER_CONTEXT_TOKEN_COOKIE")
         .ok()
         .unwrap_or("__Host-ContextToken".to_string())
+});
+
+// We're using a simple string representation for tokens instead of a struct
+// to minimize dependencies and complexity
+
+pub(super) static AUTH_SERVER_SECRET: LazyLock<Vec<u8>> =
+    LazyLock::new(|| match env::var("AUTH_SERVER_SECRET") {
+        Ok(secret) => secret.into_bytes(),
+        Err(_) => "default_secret_key_change_in_production"
+            .to_string()
+            .into_bytes(),
+    });
+
+pub(super) static USE_CONTEXT_TOKEN_COOKIE: LazyLock<bool> = LazyLock::new(|| {
+    match env::var("USE_CONTEXT_TOKEN_COOKIE") {
+        Ok(val) => match val.as_str() {
+            "true" => true,
+            "false" => false,
+            _ => panic!(
+                "USE_CONTEXT_TOKEN_COOKIE must be 'true' or 'false', got '{}'.",
+                val
+            ),
+        },
+        Err(_) => true, // Default to true when not specified
+    }
 });

--- a/oauth2_passkey/src/session/main/context_token.rs
+++ b/oauth2_passkey/src/session/main/context_token.rs
@@ -9,38 +9,15 @@ use chrono::{Duration, Utc};
 use hmac::{Hmac, Mac};
 use http::{HeaderMap, header::SET_COOKIE};
 use sha2::Sha256;
-use std::{env, sync::LazyLock};
 
 use headers::{Cookie, HeaderMapExt};
 
-use crate::session::{config::USER_CONTEXT_TOKEN_COOKIE, errors::SessionError};
+use crate::session::{
+    config::{AUTH_SERVER_SECRET, USE_CONTEXT_TOKEN_COOKIE, USER_CONTEXT_TOKEN_COOKIE},
+    errors::SessionError,
+};
 
 type HmacSha256 = Hmac<Sha256>;
-
-// We're using a simple string representation for tokens instead of a struct
-// to minimize dependencies and complexity
-
-static AUTH_SERVER_SECRET: LazyLock<Vec<u8>> =
-    LazyLock::new(|| match env::var("AUTH_SERVER_SECRET") {
-        Ok(secret) => secret.into_bytes(),
-        Err(_) => "default_secret_key_change_in_production"
-            .to_string()
-            .into_bytes(),
-    });
-
-static USE_CONTEXT_TOKEN_COOKIE: LazyLock<bool> = LazyLock::new(|| {
-    match env::var("USE_CONTEXT_TOKEN_COOKIE") {
-        Ok(val) => match val.as_str() {
-            "true" => true,
-            "false" => false,
-            _ => panic!(
-                "USE_CONTEXT_TOKEN_COOKIE must be 'true' or 'false', got '{}'.",
-                val
-            ),
-        },
-        Err(_) => true, // Default to true when not specified
-    }
-});
 
 /// Obfuscate user ID to prevent direct exposure
 /// # Arguments

--- a/oauth2_passkey/src/session/main/mod.rs
+++ b/oauth2_passkey/src/session/main/mod.rs
@@ -1,12 +1,24 @@
 mod context_token;
-// mod cookie;
 mod session;
 
-pub(crate) use session::{
-    delete_session_from_store_by_session_id, get_session_id_from_headers, renew_session_header,
-};
+use crate::session::{config::USE_CONTEXT_TOKEN_COOKIE, errors::SessionError};
+use http::HeaderMap;
+
+pub(crate) use session::{delete_session_from_store_by_session_id, get_session_id_from_headers};
 
 pub use context_token::{obfuscate_user_id, verify_context_token_and_page};
 pub use session::{
     get_user_from_session, is_authenticated_basic, is_authenticated_strict, prepare_logout_response,
 };
+
+pub(crate) async fn new_session_header(user_id: String) -> Result<HeaderMap, SessionError> {
+    let mut headers = session::create_new_session_with_uid(&user_id).await?;
+
+    if *USE_CONTEXT_TOKEN_COOKIE {
+        context_token::add_context_token_to_header(&user_id, &mut headers)?;
+    }
+
+    tracing::debug!("Created session and context token cookies: {headers:?}");
+
+    Ok(headers)
+}

--- a/oauth2_passkey/src/session/mod.rs
+++ b/oauth2_passkey/src/session/mod.rs
@@ -14,5 +14,5 @@ pub use main::{
 };
 
 pub(crate) use main::{
-    delete_session_from_store_by_session_id, get_session_id_from_headers, renew_session_header,
+    delete_session_from_store_by_session_id, get_session_id_from_headers, new_session_header,
 };

--- a/oauth2_passkey/src/session/types.rs
+++ b/oauth2_passkey/src/session/types.rs
@@ -5,14 +5,6 @@ use crate::session::errors::SessionError;
 use crate::storage::CacheData;
 use crate::userdb::User as DbUser;
 
-// Minimal session information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct SessionInfo {
-    pub(super) user_id: String,
-    // pub provider: String,
-    pub(super) expires_at: DateTime<Utc>,
-}
-
 // User information from libuserdb
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
@@ -41,7 +33,8 @@ impl From<DbUser> for User {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct StoredSession {
-    pub(super) info: SessionInfo,
+    pub(super) user_id: String,
+    pub(super) expires_at: DateTime<Utc>,
     pub(super) ttl: u64,
 }
 


### PR DESCRIPTION
- Rename `renew_session_header` to `new_session_header`
- Remove `SessionInfo` struct and directly use `user_id` and `expires_at`
- Move static configurations to `config.rs`
- Streamline session creation logic