### PR TITLE
refactor: replace page context token with CSRF token protection

### DIFF
--- a/docs/context_token_walkthrough.md
+++ b/docs/context_token_walkthrough.md
@@ -1,86 +1,84 @@
-# Session Boundary Protection with Context Tokens
+# Session Boundary Protection with Page Context Tokens
 
-This document explains how the context token mechanism works to prevent session desynchronization issues in the authentication system.
+This document explains how the page context token mechanism (based on obfuscated CSRF tokens) works to prevent session desynchronization issues in the authentication system.
 
 ## Overview
 
 The system uses a dual approach to prevent session boundary issues:
 
 1. **Explicit Registration Modes**
-   - Explicit registration modes: `RegistrationMode::AddToExistingUser` and `RegistrationMode::NewUser`
+   - Explicit registration modes: `RegistrationMode::AddToUser` and `RegistrationMode::CreateUser`
    - Separate handlers for different authentication operations
 
-2. **Signed Context Tokens for Session/Page Synchronization**
-   - Tokens contain obfuscated user_id, expiration, and signature
-   - Delivered via HTTP cookies
-   - Page context embedded in HTML/JavaScript
-   - Stateless implementation requiring no additional storage
+2. **Page Context Tokens for Session/Page Synchronization**
+   - Based on obfuscated CSRF tokens from the session
+   - CSRF tokens are included in HTTP headers for state-changing operations
+   - Obfuscated CSRF tokens are embedded in HTML/JavaScript as page context tokens
+   - Integrated with session management for simplified implementation
 
 ## Implementation Details
 
-### Context Token Structure
+### Page Context Token Mechanism
 
-A context token is a string with the format: `obfuscated_user_id:expiration:signature` where:
+The page context token mechanism (based on CSRF tokens) serves two purposes:
 
-- `obfuscated_user_id` is a HMAC-SHA256 hash of the user ID
-- `expiration` is a Unix timestamp indicating when the token expires (1 day by default)
-- `signature` is a HMAC-SHA256 signature of `obfuscated_user_id:expiration` using a server-side secret
+1. Protecting against Cross-Site Request Forgery attacks
+2. Preventing session boundary issues by verifying session continuity
+
+When a session is created, a CSRF token is generated and stored with the session data. This token is:
+
+- Required in the `X-CSRF-Token` header for all state-changing operations (POST, PUT, DELETE)
+- Obfuscated and embedded in pages as `PAGE_CONTEXT_TOKEN` for session boundary verification
 
 ### Flow for Authentication and Adding a Passkey
 
 1. **User Login**
    - When a user logs in (via OAuth2 or passkey), the system:
-     - Creates a session cookie
-     - Creates a context token cookie with the same user ID
-     - Both cookies are delivered to the client
-     - The obfuscated user ID is also embedded in the page as `PAGE_USER_CONTEXT`
+     - Creates a session cookie with a CSRF token
+     - The obfuscated CSRF token is embedded in the page as `PAGE_CONTEXT_TOKEN`
 
 2. **Adding a Passkey to an Existing User**
-   - Client initiates passkey registration with `mode: 'add_to_existing_user'`
-   - Client submits the passkey data along with the page context
-   - Server extracts the context token from cookies
+   - Client initiates passkey registration with `mode: 'add_to_user'`
+   - Client submits the passkey data with the CSRF token in the header
+   - Client may include the page context token (obfuscated CSRF token) for additional verification
    - Server verifies that:
-     - The context token is valid and not expired
-     - The token's obfuscated user ID matches the session user's obfuscated ID
-     - The page context matches the obfuscated user ID
+     - The CSRF token in the header matches the token in the session
+     - If provided, the page context token matches the obfuscated CSRF token
    - If verification passes, the passkey is associated with the user
    - If verification fails (e.g., user session changed), an error is returned
 
 3. **Creating a New User with a Passkey**
-   - Client initiates passkey registration with `mode: 'new_user'`
+   - Client initiates passkey registration with `mode: 'create_user'`
    - Client submits the passkey data to the server
    - Server creates a new user account with the passkey
-   - Server sets both session and context token cookies for the new user
+   - Server sets a new session cookie with a CSRF token for the new user
 
 ### Implementation in Code
 
-The context token functionality is implemented in `oauth2_passkey/src/session/main/context_token.rs` with these key functions:
+The page context token functionality is implemented across several files:
 
-- `obfuscate_user_id` - Hashes the user ID to prevent direct exposure
-- `generate_user_context_token` - Creates a signed token for a user
-- `verify_user_context_token` - Validates a token's signature, expiration, and user ID
-- `create_context_token_cookie` - Creates HTTP headers with the token cookie
-- `extract_context_token_from_cookies` - Extracts the token from request cookies
-- `verify_context_token_and_page` - Verifies both cookie token and page context
+- `session.rs` - Handles CSRF token verification for all state-changing operations
+- `context_token.rs` - Contains the `obfuscate_token` function for obfuscating CSRF tokens
+- `verify_context_token` - Verifies that the page context token matches the obfuscated CSRF token
 
 ## Security Considerations
 
-- User IDs are obfuscated using HMAC-SHA256 to prevent direct exposure
-- Context tokens are signed using HMAC-SHA256 to prevent tampering
-- Tokens include an expiration timestamp to limit their validity period
-- Tokens are delivered via HttpOnly cookies to prevent access via JavaScript
-- The verification process ensures the user who loaded the page is the same as the user sending the request
+- CSRF tokens are required for all state-changing operations
+- Tokens are verified against the session data to ensure session continuity
+- The obfuscated CSRF token is used as a page context token to prevent session boundary issues
+- HMAC-SHA256 is used for token obfuscation to prevent direct exposure
 - The server secret is configurable via the `AUTH_SERVER_SECRET` environment variable
-- The feature can be toggled with the `USE_CONTEXT_TOKEN_COOKIE` environment variable
 
 ## Testing
 
-You can test the context token mechanism by:
+You can test the session boundary protection by:
 
 1. Logging in as User A
 2. Opening a new passkey registration page
 3. In a different tab or browser, logging out and logging in as User B
 4. Returning to the registration page and attempting to complete registration
-5. The system should reject the operation because the context token still contains User A's ID
+5. The system should reject the operation because:
+   - The CSRF token in the header won't match User B's session
+   - The page context token (obfuscated CSRF token) won't match User B's session
 
 This protection mechanism helps prevent confused deputy problems and session desynchronization issues in multi-tab or shared browser scenarios.

--- a/oauth2_passkey/src/lib.rs
+++ b/oauth2_passkey/src/lib.rs
@@ -44,8 +44,7 @@ pub use passkey::{
 pub use session::{
     SESSION_COOKIE_NAME, SessionError, User as SessionUser, get_csrf_token_from_session,
     get_user_and_csrf_token_from_session, get_user_from_session, is_authenticated_basic,
-    is_authenticated_strict, obfuscate_user_id, prepare_logout_response,
-    verify_context_token_and_page,
+    is_authenticated_strict, obfuscate_token, prepare_logout_response, verify_context_token,
 };
 
 pub use userdb::User as DbUser;

--- a/oauth2_passkey/src/session/config.rs
+++ b/oauth2_passkey/src/session/config.rs
@@ -13,12 +13,6 @@ pub static SESSION_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
         .unwrap_or(600) // Default to 10 minutes if not set or invalid
 });
 
-pub static USER_CONTEXT_TOKEN_COOKIE: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("USER_CONTEXT_TOKEN_COOKIE")
-        .ok()
-        .unwrap_or("__Host-ContextToken".to_string())
-});
-
 // We're using a simple string representation for tokens instead of a struct
 // to minimize dependencies and complexity
 
@@ -29,17 +23,3 @@ pub(super) static AUTH_SERVER_SECRET: LazyLock<Vec<u8>> =
             .to_string()
             .into_bytes(),
     });
-
-pub(super) static USE_CONTEXT_TOKEN_COOKIE: LazyLock<bool> = LazyLock::new(|| {
-    match env::var("USE_CONTEXT_TOKEN_COOKIE") {
-        Ok(val) => match val.as_str() {
-            "true" => true,
-            "false" => false,
-            _ => panic!(
-                "USE_CONTEXT_TOKEN_COOKIE must be 'true' or 'false', got '{}'.",
-                val
-            ),
-        },
-        Err(_) => true, // Default to true when not specified
-    }
-});

--- a/oauth2_passkey/src/session/main/context_token.rs
+++ b/oauth2_passkey/src/session/main/context_token.rs
@@ -5,227 +5,56 @@
 //! user in the session, preventing session/page desynchronization.
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use chrono::{Duration, Utc};
 use hmac::{Hmac, Mac};
-use http::{HeaderMap, header::SET_COOKIE};
+use http::HeaderMap;
 use sha2::Sha256;
 
-use headers::{Cookie, HeaderMapExt};
-
-use crate::session::{
-    config::{AUTH_SERVER_SECRET, USE_CONTEXT_TOKEN_COOKIE, USER_CONTEXT_TOKEN_COOKIE},
-    errors::SessionError,
+use crate::{
+    session::{config::AUTH_SERVER_SECRET, errors::SessionError, types::StoredSession},
+    storage::GENERIC_CACHE_STORE,
 };
+
+use super::session::get_session_id_from_headers;
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Obfuscate user ID to prevent direct exposure
-/// # Arguments
-/// * `user_id` - The user ID to obfuscate
-///
-/// # Returns
-/// * `String` - The obfuscated user ID
-pub fn obfuscate_user_id(user_id: &str) -> String {
+pub fn obfuscate_token(token: &str) -> String {
     let mut mac =
         HmacSha256::new_from_slice(&AUTH_SERVER_SECRET).expect("HMAC can take key of any size");
-    mac.update(user_id.as_bytes());
+    mac.update(token.as_bytes());
     let result = mac.finalize().into_bytes();
     URL_SAFE_NO_PAD.encode(result)
 }
 
-fn generate_user_context_token(user_id: &str) -> String {
-    let expires_at = Utc::now() + Duration::days(1);
-    let expiry_str = expires_at.timestamp().to_string();
-
-    // Obfuscate user ID
-    let obfuscated_user_id = obfuscate_user_id(user_id);
-
-    // Create the data string
-    let data = format!("{}:{}", obfuscated_user_id, expiry_str);
-
-    // Sign the data with HMAC-SHA256
-    let mut mac =
-        HmacSha256::new_from_slice(&AUTH_SERVER_SECRET).expect("HMAC can take key of any size");
-    mac.update(data.as_bytes());
-    let signature = mac.finalize().into_bytes();
-    let signature_base64 = URL_SAFE_NO_PAD.encode(signature);
-
-    // Format as data:signature
-    format!("{}:{}", data, signature_base64)
-}
-
-/// Verify the user context token:
-/// 1. Verifies that the context user matches the session user ID
-/// 2. Verifies that the context token has not expired
-/// 3. Verifies that the context signature is valid
-fn verify_user_context_token(token: &str, session_user_id: &str) -> Result<(), SessionError> {
-    // Parse token parts
-    let parts: Vec<&str> = token.split(':').collect();
-    if parts.len() != 3 {
-        return Err(SessionError::ContextToken(
-            "Invalid token format".to_string(),
-        ));
-    }
-
-    let token_obfuscated_user_id = parts[0];
-    let expiry_str = parts[1];
-    let signature_base64 = parts[2];
-
-    // Verify obfuscated user ID
-    let session_obfuscated_user_id = obfuscate_user_id(session_user_id);
-    if token_obfuscated_user_id != session_obfuscated_user_id {
-        tracing::debug!(
-            "Session desynchronization detected: token user does not match session user"
-        );
-        return Err(SessionError::ContextToken(
-            "Your session has changed since this page was loaded".to_string(),
-        ));
-    }
-
-    // Check expiration
-    let expiry = expiry_str.parse::<i64>().map_err(|_| {
-        SessionError::ContextToken("Invalid expiration format in token".to_string())
-    })?;
-
-    let now = Utc::now().timestamp();
-    if now > expiry {
-        return Err(SessionError::ContextToken("Token has expired".to_string()));
-    }
-
-    // Verify signature
-    let data = format!("{}:{}", token_obfuscated_user_id, expiry_str);
-    let mut mac = HmacSha256::new_from_slice(&AUTH_SERVER_SECRET)
-        .map_err(|_| SessionError::ContextToken("Failed to create HMAC".to_string()))?;
-    mac.update(data.as_bytes());
-
-    let signature = URL_SAFE_NO_PAD
-        .decode(signature_base64)
-        .map_err(|_| SessionError::ContextToken("Invalid signature encoding".to_string()))?;
-
-    mac.verify_slice(&signature)
-        .map_err(|_| SessionError::ContextToken("Invalid token signature".to_string()))?;
-
-    Ok(())
-}
-
-pub(super) fn add_context_token_to_header(
-    user_id: &str,
-    headers: &mut HeaderMap,
-) -> Result<(), SessionError> {
-    if *USE_CONTEXT_TOKEN_COOKIE {
-        let context_headers = create_context_token_cookie(user_id);
-        for (key, value) in context_headers.iter() {
-            headers.append(key, value.clone());
-        }
-    }
-    Ok(())
-}
-
-fn create_context_token_cookie(user_id: &str) -> HeaderMap {
-    let token = generate_user_context_token(user_id);
-    let mut headers = HeaderMap::new();
-
-    // Create cookie with the token that expires in 1 day
-    let cookie = format!(
-        "{}={}; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=Strict",
-        *USER_CONTEXT_TOKEN_COOKIE, token
-    );
-
-    // Parse cookie. The parse function is used to convert the cookie string into a HeaderMap.
-    match cookie.parse() {
-        Ok(cookie_value) => {
-            headers.insert(SET_COOKIE, cookie_value);
-        }
-        Err(e) => {
-            tracing::error!("Failed to parse cookie: {}", e);
-        }
-    }
-
-    headers
-}
-
-fn extract_context_token_from_cookies(headers: &HeaderMap) -> Option<String> {
-    // Try to extract Cookie header
-
-    let token = headers.typed_get::<Cookie>().and_then(|cookie| {
-        // Look for our specific context token cookie
-        cookie
-            .get(&USER_CONTEXT_TOKEN_COOKIE)
-            .map(|s| s.to_string())
-    });
-
-    token
-}
-
-/// Verifies both context token and page context match the user ID
-///
-/// This function combines both verification steps:
-/// 1. Extracts and verifies the context token from cookies
-/// 2. Verifies that any page context (if provided) matches the user ID
-///
-/// Returns SessionError if verification fails.
-///
-/// # Arguments
-/// * `headers` - The headers to extract the context token from
-/// * `page_context` - The page context to verify
-/// * `user_id` - The user ID to verify against
-///
-/// # Returns
-/// * `Result<(), SessionError>` - The result of the verification, or an error
-pub fn verify_context_token_and_page(
+/// Verify that received context_token(obfuscated csrf_token) as a part of query param is same as the one
+/// in the current user's session cache.
+pub async fn verify_context_token(
     headers: &HeaderMap,
     page_context: Option<&String>,
-    user_id: &str,
 ) -> Result<(), SessionError> {
-    if *USE_CONTEXT_TOKEN_COOKIE {
-        // Extract token
-        let context_token = extract_context_token_from_cookies(headers)
-            .ok_or_else(|| SessionError::ContextToken("Context token missing".to_string()))?;
+    let session_id: &str = match get_session_id_from_headers(headers) {
+        Ok(Some(session_id)) => session_id,
+        _ => return Err(SessionError::ContextToken("Session ID missing".to_string())),
+    };
 
-        // Verify token belongs to user
-        verify_user_context_token(&context_token, user_id)?;
-    }
+    let cached_session = GENERIC_CACHE_STORE
+        .lock()
+        .await
+        .get("session", session_id)
+        .await
+        .map_err(|e| SessionError::Storage(e.to_string()))?
+        .ok_or(SessionError::SessionError)?;
 
-    // Verify page context matches user (if provided)
-    match page_context {
-        // If page context is provided, it must match the obfuscated user ID
-        Some(context) if context != &obfuscate_user_id(user_id) => {
-            // Some(context) if !context.is_empty() && context != &obfuscate_user_id(user_id) => {
+    let stored_session: StoredSession = cached_session.try_into()?;
+
+    if let Some(page_context) = page_context {
+        if page_context.as_str() != obfuscate_token(&stored_session.csrf_token) {
+            tracing::error!("Page context does not match session user");
             return Err(SessionError::ContextToken(
                 "Page context does not match session user".to_string(),
             ));
         }
-        _ => {} // Do nothing for None or matching context
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_generate_and_verify_token() {
-        let user_id = "test-user-123";
-        let token = generate_user_context_token(user_id);
-
-        // Verification should succeed with matching user ID
-        assert!(verify_user_context_token(&token, user_id).is_ok());
-
-        // Verification should fail with different user ID
-        assert!(verify_user_context_token(&token, "different-user").is_err());
-    }
-
-    #[test]
-    fn test_cookie_creation_and_extraction() {
-        let user_id = "test-user-456";
-        let headers = create_context_token_cookie(user_id);
-
-        // Check that cookie header was set
-        assert!(headers.contains_key(SET_COOKIE));
-
-        // We can't easily test extraction here since it requires parsing
-        // the Set-Cookie header into a Cookie header, which is complex in testing
-    }
 }

--- a/oauth2_passkey/src/session/main/mod.rs
+++ b/oauth2_passkey/src/session/main/mod.rs
@@ -1,24 +1,19 @@
 mod context_token;
 mod session;
 
-use crate::session::{config::USE_CONTEXT_TOKEN_COOKIE, errors::SessionError};
+use crate::session::errors::SessionError;
 use http::HeaderMap;
 
 pub(crate) use session::{delete_session_from_store_by_session_id, get_session_id_from_headers};
 
-pub use context_token::{obfuscate_user_id, verify_context_token_and_page};
+pub use context_token::{obfuscate_token, verify_context_token};
 pub use session::{
     get_csrf_token_from_session, get_user_and_csrf_token_from_session, get_user_from_session,
     is_authenticated_basic, is_authenticated_strict, prepare_logout_response,
 };
 
 pub(crate) async fn new_session_header(user_id: String) -> Result<HeaderMap, SessionError> {
-    let mut headers = session::create_new_session_with_uid(&user_id).await?;
-
-    if *USE_CONTEXT_TOKEN_COOKIE {
-        context_token::add_context_token_to_header(&user_id, &mut headers)?;
-    }
-
+    let headers = session::create_new_session_with_uid(&user_id).await?;
     tracing::debug!("Created session and context token cookies: {headers:?}");
 
     Ok(headers)

--- a/oauth2_passkey/src/session/mod.rs
+++ b/oauth2_passkey/src/session/mod.rs
@@ -10,8 +10,8 @@ pub use types::User; // Required for session data
 
 pub use main::{
     get_csrf_token_from_session, get_user_and_csrf_token_from_session, get_user_from_session,
-    is_authenticated_basic, is_authenticated_strict, obfuscate_user_id, prepare_logout_response,
-    verify_context_token_and_page,
+    is_authenticated_basic, is_authenticated_strict, obfuscate_token, prepare_logout_response,
+    verify_context_token,
 };
 
 pub(crate) use main::{

--- a/oauth2_passkey_axum/src/passkey.rs
+++ b/oauth2_passkey_axum/src/passkey.rs
@@ -54,27 +54,24 @@ pub fn passkey_well_known_router() -> Router {
 
 async fn handle_start_registration(
     auth_user: Option<AuthUser>,
-    request_headers: HeaderMap,
     Json(request): Json<RegistrationStartRequest>,
 ) -> Result<Json<RegistrationOptions>, (StatusCode, String)> {
     let session_user = auth_user.as_ref().map(SessionUser::from);
 
     // Use the new wrapper function that handles headers directly
-    let registration_options =
-        handle_start_registration_core(session_user.as_ref(), &request_headers, request)
-            .await
-            .into_response_error()?;
+    let registration_options = handle_start_registration_core(session_user.as_ref(), request)
+        .await
+        .into_response_error()?;
 
     Ok(Json(registration_options))
 }
 
 async fn handle_finish_registration(
     auth_user: Option<AuthUser>,
-    request_headers: HeaderMap,
     Json(reg_data): Json<RegisterCredential>,
 ) -> Result<(HeaderMap, String), (StatusCode, String)> {
     let session_user = auth_user.as_ref().map(SessionUser::from);
-    handle_finish_registration_core(session_user.as_ref(), &request_headers, reg_data)
+    handle_finish_registration_core(session_user.as_ref(), reg_data)
         .await
         .into_response_error()
 }

--- a/oauth2_passkey_axum/src/user/optional.rs
+++ b/oauth2_passkey_axum/src/user/optional.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 
 use oauth2_passkey::{
     AuthenticatorInfo, O2P_ROUTE_PREFIX, get_authenticator_info_batch, list_accounts_core,
-    list_credentials_core, obfuscate_user_id,
+    list_credentials_core, obfuscate_token,
 };
 
 use crate::config::O2P_REDIRECT_ANON;
@@ -106,7 +106,7 @@ struct UserSummaryTemplate {
     pub oauth2_accounts: Vec<TemplateAccount>,
     pub o2p_route_prefix: String,
     pub o2p_redirect_anon: String,
-    pub obfuscated_user_id: String,
+    pub page_context_token: String,
 }
 
 impl UserSummaryTemplate {
@@ -117,7 +117,7 @@ impl UserSummaryTemplate {
         o2p_route_prefix: String,
         o2p_redirect_anon: String,
     ) -> Self {
-        let obfuscated_user_id = obfuscate_user_id(&user.id);
+        let page_context_token = obfuscate_token(&user.csrf_token);
 
         Self {
             user: TemplateAuthUser {
@@ -133,7 +133,7 @@ impl UserSummaryTemplate {
             oauth2_accounts,
             o2p_route_prefix,
             o2p_redirect_anon,
-            obfuscated_user_id,
+            page_context_token,
         }
     }
 }

--- a/oauth2_passkey_axum/static/admin_user.js
+++ b/oauth2_passkey_axum/static/admin_user.js
@@ -43,7 +43,6 @@ function unlinkOAuth2Account(provider, providerUserId, accountUserId) {
                 },
                 body: JSON.stringify({
                     user_id: accountUserId,
-                    page_user_context: PAGE_USER_CONTEXT
                 }),
             }
         )
@@ -66,7 +65,6 @@ function deletePasskeyCredential(credentialId, credentialUserId) {
     if (confirm("Are you sure you want to unlink this passkey credential?")) {
         console.log("Deleting passkey credential with ID: " + credentialId);
         console.log("User ID: " + credentialUserId);
-        console.log("Page user context: " + PAGE_USER_CONTEXT);
         fetch(`${O2P_ROUTE_PREFIX}/admin/delete_passkey_credential/${credentialId}`, {
             method: "DELETE",
             headers: {
@@ -75,7 +73,6 @@ function deletePasskeyCredential(credentialId, credentialUserId) {
             },
             body: JSON.stringify({
                 user_id: credentialUserId,
-                page_user_context: PAGE_USER_CONTEXT,
             }),
         })
         .then(async (response) => {

--- a/oauth2_passkey_axum/static/passkey.js
+++ b/oauth2_passkey_axum/static/passkey.js
@@ -195,12 +195,10 @@ async function startRegistration(mode, username = null, displayname = null) {
         // Log the explicitly provided mode
         console.log('Registration mode:', mode);
 
-        // Include mode and page context for session boundary verification
         const request = {
             username,
             displayname,
             mode: mode,
-            page_context: typeof PAGE_USER_CONTEXT !== 'undefined' ? PAGE_USER_CONTEXT : '',
         };
 
         let startResponse;
@@ -247,14 +245,11 @@ async function startRegistration(mode, username = null, displayname = null) {
             },
             user_handle: userHandle,
             mode: mode,
-            page_context: typeof PAGE_USER_CONTEXT !== 'undefined' ? PAGE_USER_CONTEXT : '',
         };
 
         console.log('Registration response:', credentialResponse);
 
         // Use the single registration finish endpoint
-        // The mode has already been verified at the start stage, and the page_context
-        // is included in the credential for additional verification
         const finishResponse = await fetch(O2P_ROUTE_PREFIX + '/passkey/register/finish', {
             method: 'POST',
             headers: {

--- a/oauth2_passkey_axum/templates/admin_user.j2
+++ b/oauth2_passkey_axum/templates/admin_user.j2
@@ -32,7 +32,6 @@
         <div class="item" id="user-info-display">
             <div class="item-detail"><strong>User ID:</strong> {{ user.id }}</div>
             <div class="item-detail"><strong>Is Admin:</strong> {{ user.is_admin }}</div>
-            <div class="item-detail"><strong>Obfuscated User ID:</strong> {{ obfuscated_user_id }}</div>
             <div class="item-detail"><strong>Account:</strong> {{ user.account }}</div>
             <div class="item-detail"><strong>Label:</strong> {{ user.label }}</div>
             <div class="item-detail"><strong>Created:</strong> {{ user.created_at }}</div>
@@ -122,8 +121,6 @@
 
     <script src="{{o2p_route_prefix}}/admin/admin_user.js"></script>
     <script>
-        // Page context for session boundary protection
-        const PAGE_USER_CONTEXT = "{{ obfuscated_user_id }}";
         // Global route prefix for API calls
         const O2P_ROUTE_PREFIX = "{{o2p_route_prefix}}";
         const accountName = "{{user.account}}";

--- a/oauth2_passkey_axum/templates/admin_user_list.j2
+++ b/oauth2_passkey_axum/templates/admin_user_list.j2
@@ -39,6 +39,7 @@
         </table>
     </div>
     <script>
+        const csrfToken = "_NOT_SET_YET_";
         function Logout() {
             window.location.href = "{{o2p_route_prefix}}/user/logout?redirect={{o2p_redirect_anon}}";
         }

--- a/oauth2_passkey_axum/templates/summary.j2
+++ b/oauth2_passkey_axum/templates/summary.j2
@@ -194,7 +194,7 @@
     <script src="{{o2p_route_prefix}}/user/summary.js"></script>
     <script>
         // Page context for session boundary protection
-        const PAGE_USER_CONTEXT = "{{ obfuscated_user_id }}";
+        const PAGE_USER_CONTEXT = "{{ page_context_token }}";
         // Global route prefix for API calls
         const O2P_ROUTE_PREFIX = "{{o2p_route_prefix}}";
         const accountName = "{{user.account}}";


### PR DESCRIPTION
This commit simplifies the security model by removing the separate page context token mechanism and leveraging the existing CSRF token protection for session boundary verification. The changes:

- Remove the redundant context token cookie mechanism
- Replace obfuscated user ID with obfuscated CSRF token for page context
- Simplify API by removing unnecessary parameters and fields
- Update templates and client-side code to use the simplified approach
- Maintain equivalent security guarantees with less code

This change reduces complexity while maintaining the same level of protection against session boundary issues and CSRF attacks.