### PR TITLE
feat: Add ability to manage user admin status

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -13,24 +13,11 @@
   - async-backtrace
   - tokio-console https://zenn.dev/tfutada/articles/4dbb9659bb8102
 - Replace "if let", "unwrap_or_else", "ok_or_else" etc. with "match", where appropriate.
-- Implement Admin Account idea
-  - ~~Modify the User table to add admin flag and sequence number.~~
-  - ~~The first user i.e. sequence number 1 will be the admin.~~
-  - He has the power to modify all attributes of all users.
-  - Can list and manage all users.
-- Does page context token verification work as csrf protection?
-  - Suppose the situation where a malicious user tries to let the admin give him admin privileges, or modify arbitrary user's account details.
+
 - Modify demo pages to include link to available pages.
 - Make demo-oauth2 and demo-passkey pages to implement login page and account summary page without relying on oauth2_passkey_axum's summary and login pages.
 
 - Syncing of credentials using signalAllAcceptedCredentials?
-
-- Create a page to list all users which will be accessible only by admin.
-  - The page will have button that will delete the user.
-  - The page will have button that will toggle the admin flag.
-  - The page will have button or link to the summary page of the user.
-  - In the summary page, the admin can unlink OAuth2 accounts and delete passkey credentials.
-  - I am wondering if we should utilize existing handler for summary page for a login user and helper functions or create a new handler and set of helper functions dedicated for admin. My worries is that we can reduce the code by utilizing existing handlers but we have functions with mixed concerns, thus resulting in higher chances of creating security bugs
 
 - Modify is_authenticated middleware so that it can embed csrf_token in the extention field.
 
@@ -167,6 +154,21 @@ Performance:
 
 - The feature flags (admin-pages and optional-pages) are introduced but their purpose isn't well-documented in the code.
 
+- Create a page to list all users which will be accessible only by admin.
+  - The page will have button that will delete the user.
+  - The page will have button that will toggle the admin flag.
+  - The page will have button or link to the summary page of the user.
+  - In the summary page, the admin can unlink OAuth2 accounts and delete passkey credentials.
+  - I am wondering if we should utilize existing handler for summary page for a login user and helper functions or create a new handler and set of helper functions dedicated for admin. My worries is that we can reduce the code by utilizing existing handlers but we have functions with mixed concerns, thus resulting in higher chances of creating security bugs
+
+- Does page context token verification work as csrf protection?
+  - Suppose the situation where a malicious user tries to let the admin give him admin privileges, or modify arbitrary user's account details.
+
+- Implement Admin Account idea
+  - ~~Modify the User table to add admin flag and sequence number.~~
+  - ~~The first user i.e. sequence number 1 will be the admin.~~
+  - He has the power to modify all attributes of all users.
+  - Can list and manage all users.
 
 ## Memo
 

--- a/oauth2_passkey/src/coordination/mod.rs
+++ b/oauth2_passkey/src/coordination/mod.rs
@@ -10,7 +10,7 @@ pub use oauth2::{
 
 pub use admin::{
     delete_oauth2_account_admin, delete_passkey_credential_admin, delete_user_account_admin,
-    get_all_users, get_user,
+    get_all_users, get_user, update_user_admin_status,
 };
 pub use passkey::{
     RegistrationStartRequest, delete_passkey_credential_core, handle_finish_authentication_core,

--- a/oauth2_passkey/src/lib.rs
+++ b/oauth2_passkey/src/lib.rs
@@ -15,8 +15,8 @@ mod utils;
 // Re-export the main coordination components
 // pub use coordinate::AuthError;
 pub use coordination::{
-    CoordinationError, RegistrationStartRequest, delete_passkey_credential_core, get_all_users,
-    get_user, handle_finish_authentication_core, handle_finish_registration_core,
+    CoordinationError, RegistrationStartRequest, get_all_users, get_user,
+    handle_finish_authentication_core, handle_finish_registration_core,
     handle_start_authentication_core, handle_start_registration_core, list_credentials_core,
 };
 // pub use coordinate::{
@@ -26,8 +26,9 @@ pub use coordination::{
 
 pub use coordination::{
     delete_oauth2_account_admin, delete_oauth2_account_core, delete_passkey_credential_admin,
-    delete_user_account, delete_user_account_admin, get_authorized_core, list_accounts_core,
-    post_authorized_core, update_passkey_credential_core, update_user_account,
+    delete_passkey_credential_core, delete_user_account, delete_user_account_admin,
+    get_authorized_core, list_accounts_core, post_authorized_core, update_passkey_credential_core,
+    update_user_account, update_user_admin_status,
 };
 
 // Re-export the route prefixes

--- a/oauth2_passkey_axum/src/admin/default.rs
+++ b/oauth2_passkey_axum/src/admin/default.rs
@@ -4,12 +4,12 @@ use axum::{
     extract::{Json as ExtractJson, Path},
     http::StatusCode,
     response::Html,
-    routing::{delete, get},
+    routing::{delete, get, put},
 };
 
 use oauth2_passkey::{
-    DbUser, O2P_ROUTE_PREFIX, delete_oauth2_account_core, delete_passkey_credential_core,
-    delete_user_account_admin,
+    DbUser, O2P_ROUTE_PREFIX, SessionUser, delete_oauth2_account_core,
+    delete_passkey_credential_core, delete_user_account_admin, update_user_admin_status,
 };
 
 use super::super::error::IntoResponseError;
@@ -28,6 +28,7 @@ pub(super) fn router() -> Router<()> {
             "/delete_oauth2_account/{provider}/{provider_user_id}",
             delete(delete_oauth2_account),
         )
+        .route("/update_admin_status", put(update_admin_status_handler))
 }
 
 #[derive(Template)]
@@ -36,6 +37,7 @@ struct UserListTemplate {
     users: Vec<DbUser>,
     o2p_route_prefix: String,
     o2p_redirect_anon: String,
+    csrf_token: String,
 }
 
 async fn list_users(auth_user: AuthUser) -> Result<Html<String>, (StatusCode, String)> {
@@ -49,11 +51,14 @@ async fn list_users(auth_user: AuthUser) -> Result<Html<String>, (StatusCode, St
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
+    let csrf_token = auth_user.csrf_token.clone();
+
     // Render the template
     let template = UserListTemplate {
         users,
         o2p_route_prefix: O2P_ROUTE_PREFIX.to_string(),
         o2p_redirect_anon: O2P_REDIRECT_ANON.to_string(),
+        csrf_token,
     };
     Ok(Html(template.render().map_err(|e| {
         (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
@@ -129,4 +134,41 @@ async fn delete_oauth2_account(
         .await
         .map(|()| StatusCode::NO_CONTENT)
         .into_response_error()
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct UpdateAdminStatusRequest {
+    user_id: String,
+    is_admin: bool,
+}
+
+pub(super) async fn update_admin_status_handler(
+    auth_user: AuthUser,
+    ExtractJson(payload): ExtractJson<UpdateAdminStatusRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Convert AuthUser to SessionUser for the core function
+    let session_user = SessionUser::from(&auth_user);
+
+    // Verify that the user has admin privileges
+    if !session_user.is_admin {
+        tracing::warn!(
+            "User {} is not authorized to update admin status",
+            session_user.id
+        );
+        return Err((StatusCode::UNAUTHORIZED, "Not authorized".to_string()));
+    }
+
+    // Call the core function to update the user's admin status
+    update_user_admin_status(&session_user, &payload.user_id, payload.is_admin)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    tracing::debug!(
+        "User admin status updated: {} is_admin={} by {}",
+        payload.user_id,
+        payload.is_admin,
+        session_user.id
+    );
+
+    Ok(StatusCode::OK)
 }

--- a/oauth2_passkey_axum/src/admin/optional.rs
+++ b/oauth2_passkey_axum/src/admin/optional.rs
@@ -65,6 +65,7 @@ struct TemplateUser {
     pub label: String,
     pub created_at: String,
     pub updated_at: String,
+    pub sequence_number: Option<i64>,
 }
 
 #[derive(Template)]
@@ -93,6 +94,7 @@ impl UserSummaryTemplate {
                 label: user.label.clone(),
                 created_at: format_date_tz(&user.created_at, "JST"),
                 updated_at: format_date_tz(&user.updated_at, "JST"),
+                sequence_number: user.sequence_number,
             },
             csrf_token,
             passkey_credentials,

--- a/oauth2_passkey_axum/static/admin_user.js
+++ b/oauth2_passkey_axum/static/admin_user.js
@@ -2,8 +2,12 @@ window.addEventListener("error", function (event) {
     console.error("Uncaught error:", event.error);
 });
 
-function DeleteAccount() {
-    if (confirm(`Are you sure you want to delete the account ${accountName}?`)) {
+function DeleteAccount(userIdToDelete) {
+    // If userIdToDelete is provided, use it; otherwise use the global userId
+    const targetUserId = userIdToDelete || userId;
+    const targetAccountName = userIdToDelete ? "this account" : accountName;
+    
+    if (confirm(`Are you sure you want to delete ${targetAccountName}?`)) {
         fetch(`${O2P_ROUTE_PREFIX}/admin/delete_user`, {
             method: "DELETE",
             headers: {
@@ -11,7 +15,7 @@ function DeleteAccount() {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                user_id: userId
+                user_id: targetUserId
             }),
         })
         .then((response) => {
@@ -88,6 +92,55 @@ function deletePasskeyCredential(credentialId, credentialUserId) {
                     console.error("Error parsing response:", parseError);
                 }
                 throw new Error(`Failed to unlink passkey credential: ${errorText}`);
+            }
+        })
+        .catch((error) => {
+            console.error(`Error: ${error.message}`);
+            alert(`Error: ${error.message}`);
+        });
+    }
+}
+
+function toggleAdminStatus(userId, currentStatus) {
+    const newStatus = !currentStatus;
+    const actionText = newStatus ? "make admin" : "remove admin status from";
+    
+    if (confirm(`Are you sure you want to ${actionText} this user?`)) {
+        fetch(`${O2P_ROUTE_PREFIX}/admin/update_admin_status`, {
+            method: "PUT",
+            headers: {
+                "X-CSRF-Token": `${csrfToken}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                user_id: userId,
+                is_admin: newStatus
+            }),
+        })
+        .then(async (response) => {
+            if (response.ok) {
+                // Update the UI without refreshing the page
+                const statusElement = document.getElementById(`admin-status-${userId}`);
+                if (statusElement) {
+                    statusElement.textContent = newStatus.toString();
+                }
+                
+                // Update the button onclick attribute with the new status
+                const button = document.querySelector(`button[onclick="toggleAdminStatus('${userId}', ${currentStatus})"]`);
+                if (button) {
+                    button.setAttribute("onclick", `toggleAdminStatus('${userId}', ${newStatus})`);
+                }
+                
+                alert(`User admin status updated successfully.`);
+            } else {
+                // Parse error response safely
+                let errorText = "Unknown error";
+                try {
+                    errorText = await response.text();
+                } catch (parseError) {
+                    console.error("Error parsing response:", parseError);
+                }
+                throw new Error(`Failed to update admin status: ${errorText}`);
             }
         })
         .catch((error) => {

--- a/oauth2_passkey_axum/templates/admin_user.j2
+++ b/oauth2_passkey_axum/templates/admin_user.j2
@@ -31,7 +31,16 @@
         </div>
         <div class="item" id="user-info-display">
             <div class="item-detail"><strong>User ID:</strong> {{ user.id }}</div>
-            <div class="item-detail"><strong>Is Admin:</strong> {{ user.is_admin }}</div>
+            <div class="item-detail">
+                <strong>Is Admin:</strong> 
+                {% if user.sequence_number.is_some() && user.sequence_number.unwrap() == 1 %}
+                    <span>{{ user.is_admin }} (First User)</span>
+                {% else %}
+                    <button onclick="toggleAdminStatus('{{ user.id }}', {{ user.is_admin }})">
+                        <span id="admin-status-{{ user.id }}">{{ user.is_admin }}</span>
+                    </button>
+                {% endif %}
+            </div>
             <div class="item-detail"><strong>Account:</strong> {{ user.account }}</div>
             <div class="item-detail"><strong>Label:</strong> {{ user.label }}</div>
             <div class="item-detail"><strong>Created:</strong> {{ user.created_at }}</div>

--- a/oauth2_passkey_axum/templates/admin_user_list.j2
+++ b/oauth2_passkey_axum/templates/admin_user_list.j2
@@ -28,18 +28,31 @@
                     <td><a href="{{o2p_route_prefix}}/admin/user/{{ user.id }}">{{ user.id }}</a></td>
                     <td>{{ user.account }}</td>
                     <td>{{ user.label }}</td>
-                    <td>{{ user.is_admin }}</td>
-                    <td>
-                        <button onclick="DeleteAccount({{ user.id }})" class="action-button delete-button">Delete</button>
-                        <button onclick="Logout({{ user.id }})" class="action-button">Logout</button>
-                    </td>
+                    {% if user.sequence_number.is_some() && user.sequence_number.unwrap() == 1 %}
+                        <td>
+                            <span>{{ user.is_admin }}</span>
+                        </td>
+                        <td>
+                        </td>
+                    {% else %}
+                        <td>
+                            <button onclick="toggleAdminStatus('{{ user.id }}', {{ user.is_admin }})">
+                                <span id="admin-status-{{ user.id }}">{{ user.is_admin }}</span>
+                            </button>
+                        </td>
+                        <td>
+                            <button onclick="DeleteAccount('{{ user.id }}')" class="action-button delete-button">Delete</button>
+                        </td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
     </div>
+    <script src="{{o2p_route_prefix}}/admin/admin_user.js"></script>
     <script>
-        const csrfToken = "_NOT_SET_YET_";
+        const csrfToken = "{{csrf_token}}";
+        const O2P_ROUTE_PREFIX = "{{o2p_route_prefix}}";
         function Logout() {
             window.location.href = "{{o2p_route_prefix}}/user/logout?redirect={{o2p_redirect_anon}}";
         }


### PR DESCRIPTION
Implement functionality to allow administrators to grant or revoke admin privileges for other users. The implementation includes:

- Core coordination function to update user admin status
- API endpoint in the admin interface
- UI elements to toggle admin status from user list and detail pages
- Security measures to prevent modifying the first user's admin status
- CSRF protection for all admin operations

This change enhances the administrative capabilities while maintaining security by ensuring the first admin user always retains their privileges.