### PR TITLE
feat: Add X-CSRF-Token header and improve CSRF validation

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -19,8 +19,8 @@
 
 - Syncing of credentials using signalAllAcceptedCredentials?
 
-- Modify is_authenticated middleware so that it can embed csrf_token in the extention field.
-
+- Re-examine the role of page context token.
+- Re-examine the current implementation of CSRF protection in OAuth2 flow.
 
 ## ChatGPT's assessment
 
@@ -175,6 +175,9 @@ Performance:
   - ~~The first user i.e. sequence number 1 will be the admin.~~
   - He has the power to modify all attributes of all users.
   - Can list and manage all users.
+
+- Modify is_authenticated middleware so that it can embed csrf_token in the extention field.
+- csrf_token is also automatically delivered to the client as an X-CSRF-Token response header.
 
 ## Memo
 

--- a/demo01/templates/p3.j2
+++ b/demo01/templates/p3.j2
@@ -21,6 +21,32 @@
         .user-info dd {
             margin-left: 1rem;
         }
+
+        .button-container {
+            margin: 1rem 0;
+        }
+
+        button {
+            padding: 0.5rem 1rem;
+            margin-right: 1rem;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background-color: #45a049;
+        }
+
+        #result {
+            margin-top: 1rem;
+            padding: 1rem;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            display: none;
+        }
     </style>
 </head>
 
@@ -30,7 +56,62 @@
     {{message}}
     </div>
 
+    <div class="button-container">
+        <button id="withCsrf">POST with CSRF Token</button>
+        <button id="withoutCsrf">POST without CSRF Token</button>
+    </div>
+
+    <div id="result"></div>
+
     <p><a href="{{ prefix }}/user/logout?redirect=/">Logout</a></p>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const resultDiv = document.getElementById('result');
+            let csrfToken = null;
+
+            // Get initial CSRF token
+            fetch(window.location.href)
+                .then(response => csrfToken = response.headers.get('X-CSRF-Token') || null);
+
+            // Handle button clicks
+            document.querySelectorAll('#withCsrf, #withoutCsrf').forEach(button => {
+                button.addEventListener('click', async function() {
+                    let includeCsrf = false;
+                    if (this.id === 'withCsrf') {
+                        includeCsrf = true;
+                    }
+
+                    // Show loading state
+                    resultDiv.style.display = 'block';
+                    resultDiv.textContent = 'Sending request...';
+
+                    try {
+                        // Prepare headers
+                        const headers = { 'Content-Type': 'application/json' };
+                        if (includeCsrf && csrfToken) headers['X-CSRF-Token'] = csrfToken;
+
+                        // Send request
+                        const response = await fetch('/p3', {
+                            method: 'POST',
+                            headers: headers,
+                            body: JSON.stringify({ test: 'data' })
+                        });
+
+                        // Display result
+                        const text = await response.text();
+                        resultDiv.textContent = `Response (${response.status}): ${text}`;
+
+                        // Update token if available
+                        const newToken = response.headers.get('X-CSRF-Token');
+                        if (newToken) csrfToken = newToken;
+                    } catch (error) {
+                        resultDiv.textContent = `Error: ${error.message}`;
+                    }
+                });
+            });
+        });
+    </script>
 </body>
 
 </html>

--- a/demo01/templates/p4.j2
+++ b/demo01/templates/p4.j2
@@ -49,6 +49,10 @@
                 <td>Updated At</td>
                 <td>{{ user.updated_at }}</td>
             </tr>
+            <tr>
+                <td>CSRF Token</td>
+                <td>{{ user.csrf_token }}</td>
+            </tr>
         </table>
     </div>
 

--- a/demo01/templates/p5.j2
+++ b/demo01/templates/p5.j2
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Protected Area</title>
+    <style>
+        .user-info {
+            background: #f5f5f5;
+            border-radius: 8px;
+            padding: 1rem;
+            margin: 1rem 0;
+        }
+
+        .user-info dt {
+            font-weight: bold;
+            margin-top: 0.5rem;
+        }
+
+        .user-info dd {
+            margin-left: 1rem;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Welcome to the Protected Area</h1>
+    <div class="user-info">
+    {{message}}
+    </div>
+    <div class="user-info">
+    CSRF Token: {{ csrf_token }}
+    </div>
+    <p><a href="{{ prefix }}/user/logout?redirect=/">Logout</a></p>
+</body>
+
+</html>

--- a/dot.env.example
+++ b/dot.env.example
@@ -53,7 +53,9 @@ O2P_ROUTE_PREFIX='/o2p'
 # Default: '/o2p/user/summary'
 #O2P_SUMMARY_URL='/o2p/user/summary'
 
-### OAuth2 Configuration ###
+# Set to true/false to enable/disable X-CSRF-Token response header
+# Default: true
+#O2P_RESPOND_WITH_X_CSRF_TOKEN=false
 
 # OAuth2 Endpoints
 # Default: 'https://accounts.google.com/o/oauth2/v2/auth'
@@ -99,7 +101,8 @@ O2P_ROUTE_PREFIX='/o2p'
 #PASSKEY_AUTHENTICATOR_ATTACHMENT='platform'
 
 # Default: 'required' (Options: 'required', 'preferred', 'discouraged')
-# resident key = discoverable credential #PASSKEY_RESIDENT_KEY='required'
+# resident key = discoverable credential
+#PASSKEY_RESIDENT_KEY='required'
 # Default: true (Options: true, false)
 #PASSKEY_REQUIRE_RESIDENT_KEY=true
 # Default: 'discouraged' (Options: 'required', 'preferred', 'discouraged')

--- a/oauth2_passkey/src/lib.rs
+++ b/oauth2_passkey/src/lib.rs
@@ -43,9 +43,11 @@ pub use passkey::{
 };
 
 pub use session::{
-    SESSION_COOKIE_NAME, SessionError, User as SessionUser, get_csrf_token_from_session,
+    CsrfToken, SESSION_COOKIE_NAME, SessionError, User as SessionUser, get_csrf_token_from_session,
     get_user_and_csrf_token_from_session, get_user_from_session, is_authenticated_basic,
-    is_authenticated_strict, obfuscate_token, prepare_logout_response, verify_context_token,
+    is_authenticated_basic_then_csrf, is_authenticated_basic_then_user_and_csrf,
+    is_authenticated_strict, is_authenticated_strict_then_csrf, obfuscate_token,
+    prepare_logout_response, verify_context_token,
 };
 
 pub use userdb::User as DbUser;

--- a/oauth2_passkey/src/session/errors.rs
+++ b/oauth2_passkey/src/session/errors.rs
@@ -20,6 +20,9 @@ pub enum SessionError {
     #[error("Context token error: {0}")]
     ContextToken(String),
 
+    #[error("CSRF token error: {0}")]
+    CsrfToken(String),
+
     /// Error from utils operations
     #[error("Utils error: {0}")]
     Utils(#[from] UtilError),

--- a/oauth2_passkey/src/session/main/context_token.rs
+++ b/oauth2_passkey/src/session/main/context_token.rs
@@ -47,11 +47,19 @@ pub async fn verify_context_token(
 
     let stored_session: StoredSession = cached_session.try_into()?;
 
-    if let Some(page_context) = page_context {
-        if page_context.as_str() != obfuscate_token(&stored_session.csrf_token) {
-            tracing::error!("Page context does not match session user");
+    match page_context {
+        Some(context) => {
+            if context.as_str() != obfuscate_token(&stored_session.csrf_token) {
+                tracing::error!("Page context does not match session user");
+                return Err(SessionError::ContextToken(
+                    "Page context does not match session user".to_string(),
+                ));
+            }
+        }
+        None => {
+            tracing::error!("Page context missing");
             return Err(SessionError::ContextToken(
-                "Page context does not match session user".to_string(),
+                "Page context missing".to_string(),
             ));
         }
     }

--- a/oauth2_passkey/src/session/main/mod.rs
+++ b/oauth2_passkey/src/session/main/mod.rs
@@ -9,7 +9,9 @@ pub(crate) use session::{delete_session_from_store_by_session_id, get_session_id
 pub use context_token::{obfuscate_token, verify_context_token};
 pub use session::{
     get_csrf_token_from_session, get_user_and_csrf_token_from_session, get_user_from_session,
-    is_authenticated_basic, is_authenticated_strict, prepare_logout_response,
+    is_authenticated_basic, is_authenticated_basic_then_csrf,
+    is_authenticated_basic_then_user_and_csrf, is_authenticated_strict,
+    is_authenticated_strict_then_csrf, prepare_logout_response,
 };
 
 pub(crate) async fn new_session_header(user_id: String) -> Result<HeaderMap, SessionError> {
@@ -18,3 +20,5 @@ pub(crate) async fn new_session_header(user_id: String) -> Result<HeaderMap, Ses
 
     Ok(headers)
 }
+
+// pub(crate) use session::create_new_session_with_uid as new_session_header;

--- a/oauth2_passkey/src/session/mod.rs
+++ b/oauth2_passkey/src/session/mod.rs
@@ -6,11 +6,13 @@ mod types;
 
 pub use config::SESSION_COOKIE_NAME; // Required for cookie configuration
 pub use errors::SessionError;
-pub use types::User; // Required for session data
+pub use types::{CsrfToken, User}; // Required for session data
 
 pub use main::{
     get_csrf_token_from_session, get_user_and_csrf_token_from_session, get_user_from_session,
-    is_authenticated_basic, is_authenticated_strict, obfuscate_token, prepare_logout_response,
+    is_authenticated_basic, is_authenticated_basic_then_csrf,
+    is_authenticated_basic_then_user_and_csrf, is_authenticated_strict,
+    is_authenticated_strict_then_csrf, obfuscate_token, prepare_logout_response,
     verify_context_token,
 };
 

--- a/oauth2_passkey/src/session/types.rs
+++ b/oauth2_passkey/src/session/types.rs
@@ -54,3 +54,27 @@ impl TryFrom<CacheData> for StoredSession {
         serde_json::from_str(&data.value).map_err(|e| SessionError::Storage(e.to_string()))
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct CsrfToken(String);
+
+impl CsrfToken {
+    pub fn new(token: String) -> Self {
+        Self(token)
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UserId(String);
+
+impl UserId {
+    pub fn new(id: String) -> Self {
+        Self(id)
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}

--- a/oauth2_passkey_axum/src/config.rs
+++ b/oauth2_passkey_axum/src/config.rs
@@ -24,3 +24,9 @@ pub static O2P_ADMIN_URL: LazyLock<String> = LazyLock::new(|| {
 
 pub static O2P_REDIRECT_ANON: LazyLock<String> =
     LazyLock::new(|| std::env::var("O2P_REDIRECT_ANON").unwrap_or_else(|_| "/".to_string()));
+
+pub static O2P_RESPOND_WITH_X_CSRF_TOKEN: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("O2P_RESPOND_WITH_X_CSRF_TOKEN")
+        .map(|val| val.to_lowercase() != "false")
+        .unwrap_or(true)
+});

--- a/oauth2_passkey_axum/src/lib.rs
+++ b/oauth2_passkey_axum/src/lib.rs
@@ -18,4 +18,4 @@ pub use router::oauth2_passkey_router;
 pub use session::AuthUser;
 
 // Re-export the route prefix and initialization function from oauth2_passkey crate
-pub use oauth2_passkey::{O2P_ROUTE_PREFIX, init};
+pub use oauth2_passkey::{CsrfToken, O2P_ROUTE_PREFIX, init};

--- a/oauth2_passkey_axum/src/middleware.rs
+++ b/oauth2_passkey_axum/src/middleware.rs
@@ -2,55 +2,110 @@ use axum::{
     extract::Request,
     http::StatusCode,
     middleware::Next,
-    response::{IntoResponse, Redirect},
+    response::{IntoResponse, Redirect, Response},
 };
 
-use super::config::O2P_REDIRECT_ANON;
+use http::header::HeaderValue;
+
+use super::config::{O2P_REDIRECT_ANON, O2P_RESPOND_WITH_X_CSRF_TOKEN};
 use super::session::AuthUser;
+use oauth2_passkey::SessionError;
 
-// Authentication checker with custom redirect URL
-pub async fn is_authenticated_401(req: Request, next: Next) -> impl IntoResponse {
-    match oauth2_passkey::is_authenticated_basic(req.headers(), req.method()).await {
-        Ok(true) => next.run(req).await,
-        Ok(false) | Err(_) => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+// Helper function to add CSRF token to response
+fn add_csrf_header(mut response: Response, csrf_token: &str) -> Response {
+    if !*O2P_RESPOND_WITH_X_CSRF_TOKEN {
+        return response;
     }
+
+    // Use from_str with error handling instead of unwrap
+    if let Ok(header_value) = HeaderValue::from_str(csrf_token) {
+        response.headers_mut().insert("X-CSRF-Token", header_value);
+    } else {
+        // Log the error but don't panic
+        tracing::error!("Failed to create CSRF header value from token");
+    }
+    response
 }
 
-pub async fn is_authenticated_redirect(req: Request, next: Next) -> impl IntoResponse {
-    match oauth2_passkey::is_authenticated_basic(req.headers(), req.method()).await {
-        Ok(true) => next.run(req).await,
-        Ok(false) | Err(_) => Redirect::temporary(O2P_REDIRECT_ANON.as_str()).into_response(),
-    }
-}
-
-// Authentication check with user retrieval.
-// Pass the user to next handler
-pub async fn is_authenticated_user_401(
-    user: Option<AuthUser>,
-    mut req: Request,
-    next: Next,
-) -> impl IntoResponse {
-    match user {
-        Some(user) => {
-            tracing::debug!("User: {:?}", user);
-            req.extensions_mut().insert(user);
-            next.run(req).await
+// Helper function to handle authentication errors
+fn handle_auth_error(err: SessionError, req: &Request, redirect_on_error: bool) -> Response {
+    match err {
+        SessionError::CsrfToken(msg) => {
+            // For CSRF errors, return 403 Forbidden with the message
+            // For redirect middleware with GET requests, redirect instead
+            if redirect_on_error && req.method() == http::Method::GET {
+                Redirect::temporary(O2P_REDIRECT_ANON.as_str()).into_response()
+            } else {
+                (StatusCode::FORBIDDEN, msg).into_response()
+            }
         }
-        None => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+        _ => {
+            // For other authentication errors
+            if redirect_on_error && req.method() == http::Method::GET {
+                Redirect::temporary(O2P_REDIRECT_ANON.as_str()).into_response()
+            } else {
+                (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+            }
+        }
     }
 }
 
-pub async fn is_authenticated_user_redirect(
-    user: Option<AuthUser>,
-    mut req: Request,
-    next: Next,
-) -> impl IntoResponse {
-    match user {
-        Some(user) => {
-            tracing::debug!("User: {:?}", user);
-            req.extensions_mut().insert(user);
-            next.run(req).await
+// Authentication checker with 401 response
+pub async fn is_authenticated_401(mut req: Request, next: Next) -> Response {
+    match oauth2_passkey::is_authenticated_basic_then_csrf(req.headers(), req.method()).await {
+        Ok(csrf_token) => {
+            // Store token in extensions for handlers that need it
+            req.extensions_mut().insert(csrf_token.clone());
+            // Run next handler and add CSRF header to the response
+            let response = next.run(req).await;
+            add_csrf_header(response, csrf_token.as_str())
         }
-        None => Redirect::temporary(O2P_REDIRECT_ANON.as_str()).into_response(),
+        Err(err) => handle_auth_error(err, &req, false),
+    }
+}
+
+// Authentication checker with redirect
+pub async fn is_authenticated_redirect(mut req: Request, next: Next) -> Response {
+    match oauth2_passkey::is_authenticated_basic_then_csrf(req.headers(), req.method()).await {
+        Ok(csrf_token) => {
+            req.extensions_mut().insert(csrf_token.clone());
+            let response = next.run(req).await;
+            add_csrf_header(response, csrf_token.as_str())
+        }
+        Err(err) => handle_auth_error(err, &req, true),
+    }
+}
+
+// Authentication check with user retrieval and 401 response
+pub async fn is_authenticated_user_401(mut req: Request, next: Next) -> Response {
+    match oauth2_passkey::is_authenticated_basic_then_user_and_csrf(req.headers(), req.method())
+        .await
+    {
+        Ok((user, csrf_token)) => {
+            let mut auth_user = AuthUser::from(user);
+            auth_user.csrf_token = csrf_token.as_str().to_string();
+            tracing::debug!("User: {:?}", auth_user);
+            req.extensions_mut().insert(auth_user);
+            let response = next.run(req).await;
+            add_csrf_header(response, csrf_token.as_str())
+        }
+        Err(err) => handle_auth_error(err, &req, false),
+    }
+}
+
+// Authentication check with user retrieval and redirect
+pub async fn is_authenticated_user_redirect(mut req: Request, next: Next) -> Response {
+    match oauth2_passkey::is_authenticated_basic_then_user_and_csrf(req.headers(), req.method())
+        .await
+    {
+        Ok((user, csrf_token)) => {
+            let mut auth_user = AuthUser::from(user);
+            auth_user.csrf_token = csrf_token.as_str().to_string();
+            tracing::debug!("User: {:?}", auth_user);
+            req.extensions_mut().insert(auth_user);
+            let response = next.run(req).await;
+            add_csrf_header(response, csrf_token.as_str())
+        }
+        Err(err) => handle_auth_error(err, &req, true),
     }
 }


### PR DESCRIPTION
Implement proper CSRF token protection with automatic header inclusion:

- Add type-safe CsrfToken and UserId wrappers
- Return 403 Forbidden with descriptive messages for CSRF errors
- Add X-CSRF-Token response header with environment variable control
- Optimize middleware to reduce conversions and improve performance
- Create demo pages showing CSRF protection in action
- Add comprehensive error handling for token validation

This implementation maintains minimal dependencies while providing robust security for state-changing requests (POST/PUT/DELETE/PATCH).