### PR TITLE
Standardize CSRF token header to X-CSRF-Token and enhance token handling

### DIFF
--- a/demo01/src/protected.rs
+++ b/demo01/src/protected.rs
@@ -46,13 +46,19 @@ pub(super) fn nested_router() -> Router<()> {
 
 // Having user as an argument causes redirect to O2P_LOGIN_URL for anonymous users by axum extractor
 pub(crate) async fn p1(user: AuthUser) -> impl IntoResponse {
-    Html(format!("Hey {}!", user.account))
+    Html(format!(
+        "Hey {}!<br/>Your CSRF Token is: {}",
+        user.account, user.csrf_token
+    ))
 }
 
 // Having user as an optional argument prevents redirect by axum extractor
 pub(crate) async fn p2(user: Option<AuthUser>) -> impl IntoResponse {
     match user {
-        Some(u) => Html(format!("Hey {}!", u.account)),
+        Some(u) => Html(format!(
+            "Hey {}!<br/>Your CSRF Token is: {}",
+            u.account, u.csrf_token
+        )),
         None => Html("Hey Anonymous User!".to_string()),
     }
 }

--- a/demo01/templates/p3.j2
+++ b/demo01/templates/p3.j2
@@ -71,8 +71,19 @@
             let csrfToken = null;
 
             // Get initial CSRF token
-            fetch(window.location.href)
-                .then(response => csrfToken = response.headers.get('X-CSRF-Token') || null);
+            fetch(window.location.href, { method: 'HEAD' })
+                .then(response => {
+                    const headers = {};
+                    response.headers.forEach((value, key) => {
+                        headers[key] = value;
+                    });
+                    console.log('Response headers:', headers);
+                    // Always use lowercase when accessing the plain object
+                    // csrfToken = headers['x-csrf-token'] || null;
+                    csrfToken = response.headers.get('X-CSRF-Token') || null;
+                    console.log('CSRF Token:', csrfToken);
+                })
+                .catch(error => console.error('Error fetching CSRF token:', error));
 
             // Handle button clicks
             document.querySelectorAll('#withCsrf, #withoutCsrf').forEach(button => {

--- a/oauth2_passkey/src/session/main/session.rs
+++ b/oauth2_passkey/src/session/main/session.rs
@@ -205,7 +205,7 @@ async fn is_authenticated(
         || method == Method::PATCH
     {
         let x_csrf_token = headers
-            .get("X-Csrf-Token")
+            .get("X-CSRF-Token")
             .and_then(|h| h.to_str().ok())
             .map(|s| s.to_string());
 

--- a/oauth2_passkey_axum/src/session.rs
+++ b/oauth2_passkey_axum/src/session.rs
@@ -116,22 +116,22 @@ where
         {
             let x_csrf_token = parts
                 .headers
-                .get("X-Csrf-Token")
+                .get("X-CSRF-Token")
                 .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
                 .ok_or_else(|| {
-                    tracing::error!("Failed to get X-Csrf-Token");
+                    tracing::error!("Failed to get X-CSRF-Token");
                     AuthRedirect::new(method.clone())
                 })?;
 
             tracing::trace!(
-                "CSRF token: X-Csrf-Token: {}, In Cache: {}",
+                "CSRF token: X-CSRF-Token: {}, In Cache: {}",
                 x_csrf_token,
                 csrf_token.as_str()
             );
 
             if x_csrf_token != csrf_token.as_str() {
                 tracing::error!(
-                    "Token mismatch, X-Csrf-Token: {}, In Cache: {}",
+                    "Token mismatch, X-CSRF-Token: {}, In Cache: {}",
                     x_csrf_token,
                     csrf_token.as_str()
                 );


### PR DESCRIPTION
- Update all instances of X-Csrf-Token to X-CSRF-Token for consistency
- Add CSRF token display to protected endpoints for debugging
- Improve frontend token fetching with HEAD method and better error handling
- Enhance logging for CSRF token validation