### PR TITLE
refactor(csrf): Make CSRF protection for OAuth2 POST callbacks config…

### DIFF
--- a/dot.env.example
+++ b/dot.env.example
@@ -74,6 +74,8 @@ O2P_ROUTE_PREFIX='/o2p'
 # Cookie Configuration
 # Default: '__Host-CsrfId'
 #OAUTH2_CSRF_COOKIE_NAME='__Host-CsrfId'
+# Default: true - Set to false to disable CSRF protection for POST callbacks (less secure but works with SameSite=Lax cookies)
+#OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS=true
 # Default: 60 seconds
 #OAUTH2_CSRF_COOKIE_MAX_AGE=60
 # Default: '__Host-SessionId'

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -48,6 +48,13 @@ pub(crate) static OAUTH2_CSRF_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
         .unwrap_or("__Host-CsrfId".to_string())
 });
 
+pub(crate) static OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS")
+        .ok()
+        .map(|s| s.to_lowercase() == "true")
+        .unwrap_or(true) // Default to true for better security
+});
+
 pub(super) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
     std::env::var("OAUTH2_CSRF_COOKIE_MAX_AGE")
         .ok()

--- a/oauth2_passkey/src/oauth2/mod.rs
+++ b/oauth2_passkey/src/oauth2/mod.rs
@@ -7,7 +7,9 @@ mod types;
 pub use main::prepare_oauth2_auth_request;
 pub use types::{AuthResponse, OAuth2Account, OAuth2Mode};
 
-pub(crate) use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME};
+pub(crate) use config::{
+    OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS,
+};
 pub(crate) use errors::OAuth2Error;
 pub(crate) use types::{StateParams, StoredToken};
 

--- a/oauth2_passkey/src/utils.rs
+++ b/oauth2_passkey/src/utils.rs
@@ -45,7 +45,6 @@ pub(crate) fn header_set_cookie(
 ) -> Result<&HeaderMap, UtilError> {
     let cookie =
         format!("{name}={value}; SameSite=Lax; Secure; HttpOnly; Path=/; Max-Age={max_age}");
-    println!("Cookie: {:#?}", cookie);
     headers.append(
         SET_COOKIE,
         cookie

--- a/oauth2_passkey_axum/src/oauth2.rs
+++ b/oauth2_passkey_axum/src/oauth2.rs
@@ -123,9 +123,10 @@ async fn get_authorized(
 ///    typed Cookie header that would be available in a standard browser navigation
 async fn post_authorized(
     headers: HeaderMap,
+    TypedHeader(cookies): TypedHeader<headers::Cookie>,
     Form(form): Form<AuthResponse>,
 ) -> Result<(HeaderMap, Redirect), (StatusCode, String)> {
-    let (headers, message) = post_authorized_core(&form, &headers)
+    let (headers, message) = post_authorized_core(&form, &cookies, &headers)
         .await
         .into_response_error()?;
 


### PR DESCRIPTION
…urable

- Introduce OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS env variable to control CSRF protection for POST callbacks.
- When enabled (default), sets CSRF cookie SameSite=None and enforces CSRF checks for POST callbacks.
- When disabled, sets SameSite=Lax and skips CSRF checks for POST callbacks, improving compatibility but reducing security.
- Update documentation and example environment file to reflect new option.
- Clean up redundant code and improve logging for CSRF state handling.

This change gives library users clear, explicit control over CSRF security vs. compatibility trade-offs in OAuth2 flows.