### PR TITLE
refactor(oauth2): control SameSite attribute based on response mode f…

### DIFF
--- a/dot.env.example
+++ b/dot.env.example
@@ -67,6 +67,8 @@ O2P_ROUTE_PREFIX='/o2p'
 # Default: 'openid+email+profile'
 #OAUTH2_SCOPE='openid+email+profile'
 # Default: 'form_post' (Options: form_post, query)
+# Note: form_post mode uses SameSite=None for CSRF cookies and only enables POST callback endpoint
+# query mode uses SameSite=Lax for CSRF cookies and only enables GET callback endpoint
 #OAUTH2_RESPONSE_MODE='form_post'
 # Default: 'code' (Options: code)
 #OAUTH2_RESPONSE_TYPE='code'
@@ -74,8 +76,6 @@ O2P_ROUTE_PREFIX='/o2p'
 # Cookie Configuration
 # Default: '__Host-CsrfId'
 #OAUTH2_CSRF_COOKIE_NAME='__Host-CsrfId'
-# Default: true - Set to false to disable CSRF protection for POST callbacks (less secure but works with SameSite=Lax cookies)
-#OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS=true
 # Default: 60 seconds
 #OAUTH2_CSRF_COOKIE_MAX_AGE=60
 # Default: '__Host-SessionId'

--- a/oauth2_passkey/src/coordination/errors.rs
+++ b/oauth2_passkey/src/coordination/errors.rs
@@ -81,6 +81,10 @@ pub enum CoordinationError {
     /// Error from utils operations
     #[error("Utils error: {0}")]
     UtilsError(UtilError),
+
+    /// Invalid response mode
+    #[error("Invalid response mode: {0}")]
+    InvalidResponseMode(String),
 }
 
 impl CoordinationError {
@@ -137,6 +141,9 @@ impl CoordinationError {
             Self::PasskeyError(err) => tracing::error!("Passkey error: {}", err),
             Self::SessionError(err) => tracing::error!("Session error: {}", err),
             Self::UtilsError(err) => tracing::error!("Utils error: {}", err),
+            Self::InvalidResponseMode(message) => {
+                tracing::error!("Invalid response mode: {}", message)
+            }
         }
         self
     }

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -17,8 +17,19 @@ pub(crate) static OAUTH2_TOKEN_URL: LazyLock<String> = LazyLock::new(|| {
 static OAUTH2_SCOPE: LazyLock<String> =
     LazyLock::new(|| std::env::var("OAUTH2_SCOPE").unwrap_or("openid+email+profile".to_string()));
 
-static OAUTH2_RESPONSE_MODE: LazyLock<String> =
-    LazyLock::new(|| std::env::var("OAUTH2_RESPONSE_MODE").unwrap_or("form_post".to_string()));
+pub(crate) static OAUTH2_RESPONSE_MODE: LazyLock<String> = LazyLock::new(|| {
+    let mode = std::env::var("OAUTH2_RESPONSE_MODE").unwrap_or("form_post".to_string());
+    match mode.to_lowercase().as_str() {
+        "form_post" => "form_post".to_string(),
+        "query" => "query".to_string(),
+        _ => {
+            panic!(
+                "Invalid OAUTH2_RESPONSE_MODE '{}'. Must be 'form_post' or 'query'.",
+                mode
+            );
+        }
+    }
+});
 
 static OAUTH2_RESPONSE_TYPE: LazyLock<String> =
     LazyLock::new(|| std::env::var("OAUTH2_RESPONSE_TYPE").unwrap_or("code".to_string()));
@@ -46,13 +57,6 @@ pub(crate) static OAUTH2_CSRF_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
     std::env::var("OAUTH2_CSRF_COOKIE_NAME")
         .ok()
         .unwrap_or("__Host-CsrfId".to_string())
-});
-
-pub(crate) static OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS")
-        .ok()
-        .map(|s| s.to_lowercase() == "true")
-        .unwrap_or(true) // Default to true for better security
 });
 
 pub(super) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {

--- a/oauth2_passkey/src/oauth2/mod.rs
+++ b/oauth2_passkey/src/oauth2/mod.rs
@@ -7,9 +7,7 @@ mod types;
 pub use main::prepare_oauth2_auth_request;
 pub use types::{AuthResponse, OAuth2Account, OAuth2Mode};
 
-pub(crate) use config::{
-    OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS,
-};
+pub(crate) use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_RESPONSE_MODE};
 pub(crate) use errors::OAuth2Error;
 pub(crate) use types::{StateParams, StoredToken};
 


### PR DESCRIPTION
…or consistent CSRF protection

- Set SameSite cookie attribute based on response mode (None for form_post, Lax for query)
- Always perform CSRF checks regardless of response mode
- Unify GET and POST authorization handlers with strict method validation
- Add validation for OAUTH2_RESPONSE_MODE (must be 'form_post' or 'query')
- Remove OAUTH2_ENABLE_CSRF_FOR_POST_CALLBACKS configuration flag
- Update documentation to clarify security implications

This change ensures consistent CSRF protection across all OAuth2 flows by properly configuring cookie attributes for each response mode, simplifying the security model while maintaining robust protection.