### PR TITLE
feat(demo): Add CSRF-protected form submission example

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -194,5 +194,5 @@ Performance:
 ## Memo
 
 ```text
-Can you take a look the following diff carefully and if we aren't introducing any bugs and every change is OK suggest a commit message plz.
+Can you take a look the following diff carefully and suggest improvements. If it doesn't introduce any bugs and every change is OK suggest a commit message plz.
 ```

--- a/demo01/Cargo.toml
+++ b/demo01/Cargo.toml
@@ -15,3 +15,5 @@ tokio = { workspace = true }
 rustls = { workspace = true }
 
 oauth2_passkey_axum = { workspace = true }
+subtle = "2.5"
+serde = { version = "1.0", features = ["derive"] }

--- a/demo01/src/protected.rs
+++ b/demo01/src/protected.rs
@@ -1,5 +1,5 @@
 use askama::Template;
-use axum::extract::Form; // Added for form data extraction
+use axum::extract::Form;
 use axum::{
     Extension, Router,
     http::StatusCode,
@@ -7,8 +7,8 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
-use serde::Deserialize; // Added for deserializing form data
-use subtle::ConstantTimeEq; // Added for constant-time CSRF token comparison
+use serde::Deserialize;
+use subtle::ConstantTimeEq;
 
 use oauth2_passkey_axum::{
     AuthUser,
@@ -39,7 +39,6 @@ pub(super) fn router() -> Router<()> {
             get(p5).route_layer(from_fn(is_authenticated_redirect)),
         )
         .route(
-            // New route for p6
             "/p6",
             get(p6)
                 .post(p6_post)
@@ -141,18 +140,16 @@ pub(crate) async fn p5(Extension(csrf_token): Extension<CsrfToken>) -> impl Into
 #[derive(Deserialize, Debug)]
 pub(crate) struct P6FormData {
     message: String,
-    csrf_token: Option<String>, // CSRF token might be missing from one form
-                                // submit_action: String,   // Removed as it's not used
+    csrf_token: Option<String>,
 }
 
-// New template for p6
 #[derive(Template)]
 #[template(path = "p6.j2")]
 struct P6Template<'a> {
-    csrf_token: &'a str, // To pre-fill in the "good" form
+    csrf_token: &'a str,
     prefix: &'a str,
-    post_result_message: Option<String>, // To display result after POST
-    post_success: bool,                  // Changed to bool
+    post_result_message: Option<String>,
+    post_success: bool,
 }
 
 // GET handler for /p6
@@ -165,7 +162,7 @@ pub(crate) async fn p6(
         csrf_token: csrf_token.as_str(),
         prefix: O2P_ROUTE_PREFIX.as_str(),
         post_result_message: None,
-        post_success: false, // Default to false, only used if post_result_message is Some
+        post_success: false,
     };
     match template.render() {
         Ok(html) => Html(html).into_response(),
@@ -181,7 +178,7 @@ pub(crate) async fn p6_post(
     Form(form_data): Form<P6FormData>,
 ) -> impl IntoResponse {
     let post_result_message_str: String;
-    let mut is_success = false; // Default to false
+    let mut is_success = false;
 
     tracing::info!(
         "p6_post received: {:?}, CSRF via header: {}",

--- a/demo01/src/protected.rs
+++ b/demo01/src/protected.rs
@@ -1,4 +1,5 @@
 use askama::Template;
+use axum::extract::Form; // Added for form data extraction
 use axum::{
     Extension, Router,
     http::StatusCode,
@@ -6,9 +7,12 @@ use axum::{
     response::{Html, IntoResponse},
     routing::get,
 };
+use serde::Deserialize; // Added for deserializing form data
+use subtle::ConstantTimeEq; // Added for constant-time CSRF token comparison
 
 use oauth2_passkey_axum::{
     AuthUser,
+    CsrfHeaderVerified,
     CsrfToken,
     O2P_ROUTE_PREFIX,
     // Middleware, redirect to O2P_REDIRECT_ANON(default: /)
@@ -33,6 +37,13 @@ pub(super) fn router() -> Router<()> {
         .route(
             "/p5",
             get(p5).route_layer(from_fn(is_authenticated_redirect)),
+        )
+        .route(
+            // New route for p6
+            "/p6",
+            get(p6)
+                .post(p6_post)
+                .route_layer(from_fn(is_authenticated_redirect)),
         )
         .nest(
             "/nested",
@@ -119,6 +130,118 @@ pub(crate) async fn p5(Extension(csrf_token): Extension<CsrfToken>) -> impl Into
         message: "The CSRF token can also be embedded in a template.",
         csrf_token: csrf_token.as_str(),
         prefix: O2P_ROUTE_PREFIX.as_str(),
+    };
+    match template.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// New struct for p6 form data
+#[derive(Deserialize, Debug)]
+pub(crate) struct P6FormData {
+    message: String,
+    csrf_token: Option<String>, // CSRF token might be missing from one form
+                                // submit_action: String,   // Removed as it's not used
+}
+
+// New template for p6
+#[derive(Template)]
+#[template(path = "p6.j2")]
+struct P6Template<'a> {
+    csrf_token: &'a str, // To pre-fill in the "good" form
+    prefix: &'a str,
+    post_result_message: Option<String>, // To display result after POST
+    post_success: bool,                  // Changed to bool
+}
+
+// GET handler for /p6
+pub(crate) async fn p6(
+    Extension(csrf_token): Extension<CsrfToken>,
+    // Extension(csrf_via_header_verified): Extension<CsrfHeaderVerified>,
+    // Extension(user): Extension<AuthUser>,
+) -> impl IntoResponse {
+    let template = P6Template {
+        csrf_token: csrf_token.as_str(),
+        prefix: O2P_ROUTE_PREFIX.as_str(),
+        post_result_message: None,
+        post_success: false, // Default to false, only used if post_result_message is Some
+    };
+    match template.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// POST handler for /p6
+pub(crate) async fn p6_post(
+    Extension(csrf_token): Extension<CsrfToken>,
+    Extension(csrf_via_header_verified): Extension<CsrfHeaderVerified>,
+    // Extension(user): Extension<AuthUser>,
+    Form(form_data): Form<P6FormData>,
+) -> impl IntoResponse {
+    let post_result_message_str: String;
+    let mut is_success = false; // Default to false
+
+    tracing::info!(
+        "p6_post received: {:?}, CSRF via header: {}",
+        form_data,
+        csrf_token.as_str()
+    );
+
+    if csrf_via_header_verified.0 {
+        // This case should ideally not happen for a direct form post without X-CSRF-Token header.
+        post_result_message_str = format!(
+            "POST successful (CSRF token verified via X-CSRF-Token header). Message: {}",
+            form_data.message
+        );
+        is_success = true;
+        tracing::info!("{}", post_result_message_str);
+    } else {
+        // X-CSRF-Token header was NOT present or not verified.
+        // Middleware allowed the request because Content-Type was form-like.
+        // We MUST manually verify the CSRF token from the form body.
+        match &form_data.csrf_token {
+            Some(token_from_form) => {
+                if token_from_form
+                    .as_bytes()
+                    .ct_eq(csrf_token.as_str().as_bytes())
+                    .into()
+                {
+                    post_result_message_str = format!(
+                        "POST successful (CSRF token from form field verified). Message: {}",
+                        form_data.message
+                    );
+                    is_success = true;
+                    tracing::info!("{}", post_result_message_str);
+                } else {
+                    post_result_message_str = format!(
+                        "CSRF token mismatch! Form token: '{}', Expected: '{}'. Message: {}",
+                        token_from_form,
+                        csrf_token.as_str(),
+                        form_data.message
+                    );
+                    // is_success remains false
+                    tracing::warn!("{}", post_result_message_str);
+                }
+            }
+            None => {
+                post_result_message_str = format!(
+                    "CSRF token missing from form! This request would typically be rejected. Message: {}",
+                    form_data.message
+                );
+                // is_success remains false
+                tracing::warn!("{}", post_result_message_str);
+            }
+        }
+    }
+
+    // Re-render the page with the result message
+    let template = P6Template {
+        csrf_token: csrf_token.as_str(),
+        prefix: O2P_ROUTE_PREFIX.as_str(),
+        post_result_message: Some(post_result_message_str),
+        post_success: is_success,
     };
     match template.render() {
         Ok(html) => Html(html).into_response(),

--- a/demo01/templates/p3.j2
+++ b/demo01/templates/p3.j2
@@ -6,22 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Protected Area</title>
     <style>
-        .user-info {
-            background: #f5f5f5;
+        .container {
+            max-width: 600px;
+            margin: auto;
+            padding: 20px;
+            /* border: 1px solid #ccc; */
             border-radius: 8px;
-            padding: 1rem;
-            margin: 1rem 0;
         }
-
-        .user-info dt {
-            font-weight: bold;
-            margin-top: 0.5rem;
-        }
-
-        .user-info dd {
-            margin-left: 1rem;
-        }
-
         .button-container {
             margin: 1rem 0;
         }
@@ -51,10 +42,9 @@
 </head>
 
 <body>
+    <div class="container">
     <h1>Welcome to the Protected Area</h1>
-    <div class="user-info">
     {{message}}
-    </div>
 
     <div class="button-container">
         <button id="withCsrf">POST with CSRF Token</button>
@@ -64,6 +54,7 @@
     <div id="result"></div>
 
     <p><a href="{{ prefix }}/user/logout?redirect=/">Logout</a></p>
+    </div>
 
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/demo01/templates/p4.j2
+++ b/demo01/templates/p4.j2
@@ -6,6 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Protected Area</title>
     <style>
+        .container {
+            max-width: 600px;
+            margin: auto;
+            padding: 20px;
+            /* border: 1px solid #ccc; */
+            border-radius: 8px;
+        }
+
         .user-info {
             background: #f5f5f5;
             border-radius: 8px;
@@ -25,6 +33,7 @@
 </head>
 
 <body>
+    <div class="container">
     <h1>Welcome to the Protected Area</h1>
     <div class="user-info">
         <h2>Your Account Information:</h2>
@@ -55,8 +64,8 @@
             </tr>
         </table>
     </div>
-
     <button onclick="Logout()">Logout</button>
+    </div>
     <script>
         function Logout() {
             window.location.href = "{{prefix}}/user/logout?redirect=/";

--- a/demo01/templates/p5.j2
+++ b/demo01/templates/p5.j2
@@ -6,6 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Protected Area</title>
     <style>
+        .container {
+            max-width: 600px;
+            margin: auto;
+            padding: 20px;
+            /* border: 1px solid #ccc; */
+            border-radius: 8px;
+        }
+
         .user-info {
             background: #f5f5f5;
             border-radius: 8px;
@@ -25,6 +33,7 @@
 </head>
 
 <body>
+<div class="container">
     <h1>Welcome to the Protected Area</h1>
     <div class="user-info">
     {{message}}
@@ -33,6 +42,7 @@
     CSRF Token: {{ csrf_token }}
     </div>
     <p><a href="{{ prefix }}/user/logout?redirect=/">Logout</a></p>
+</div>
 </body>
 
 </html>

--- a/demo01/templates/p6.j2
+++ b/demo01/templates/p6.j2
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Protected Page P6 - CSRF Form Demo</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; }
+        .container { max-width: 600px; margin: auto; padding: 20px; /* border: 1px solid #ccc; */ border-radius: 8px; }
+        h1, h2 { color: #333; }
+        label { display: block; margin-bottom: 3px; }
+        input[type="text"], input[type="submit"] { width: 100%; padding: 8px; margin-bottom: 8px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        input[type="submit"] { background-color: #4CAF50; color: white; cursor: pointer; }
+        input[type="submit"]:hover { background-color: #45a049; }
+        .result { margin-top: 20px; padding: 15px; border-radius: 4px; }
+        .success { background-color: #d4edda; color: #155724; border: 1px solid #c3e6cb; }
+        .error { background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }
+        nav { margin-bottom: 20px; }
+        nav a { margin-right: 15px; text-decoration: none; color: #007bff; }
+        nav a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <nav>
+            <a href="/">Home</a>
+            <a href="{{ prefix }}/user/summary">User Summary</a>
+            <a href="{{ prefix }}/user/logout?redirect=/">Logout</a>
+        </nav>
+
+        <h1>CSRF Form Submission Demo</h1>
+
+        <h2>With CSRF Token</h2>
+        <form method="POST" action="">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div>
+                {# <label for="message_with_csrf">Message:</label> #}
+                <input type="text" id="message_with_csrf" name="message" value="Hello with CSRF token!">
+            </div>
+            <input type="submit" value="Submit with CSRF Token">
+        </form>
+
+        <h2>Without CSRF Token</h2>
+        <form method="POST" action="">
+            <div>
+                {# <label for="message_without_csrf">Message:</label> #}
+                <input type="text" id="message_without_csrf" name="message" value="Hello without CSRF token!">
+            </div>
+            <input type="submit" value="Submit without CSRF Token (should fail or warn)">
+        </form>
+
+        {% match post_result_message %}
+        {% when Some with (message) %}
+            {# post_success will also be Some if post_result_message is Some #}
+            <div class="result {% if post_success %}success{% else %}error{% endif %}">
+                <h2>Submission Result:</h2>
+                <p>{{ message }}</p>
+            </div>
+        {% when None %}
+            {# No message to display #}
+        {% endmatch %}
+    </div>
+</body>
+</html>

--- a/oauth2_passkey/src/session/main/session.rs
+++ b/oauth2_passkey/src/session/main/session.rs
@@ -342,7 +342,7 @@ pub async fn is_authenticated_basic_then_csrf(
         (AuthenticationStatus(true), _, Some(csrf_token), csrf_via_header_verified) => {
             Ok((csrf_token, csrf_via_header_verified))
         }
-        _ => Err(SessionError::SessionError), // Or a more specific error if needed
+        _ => Err(SessionError::SessionError),
     }
 }
 

--- a/oauth2_passkey_axum/src/lib.rs
+++ b/oauth2_passkey_axum/src/lib.rs
@@ -18,4 +18,4 @@ pub use router::oauth2_passkey_router;
 pub use session::AuthUser;
 
 // Re-export the route prefix and initialization function from oauth2_passkey crate
-pub use oauth2_passkey::{CsrfToken, O2P_ROUTE_PREFIX, init};
+pub use oauth2_passkey::{CsrfHeaderVerified, CsrfToken, O2P_ROUTE_PREFIX, init};


### PR DESCRIPTION
- Add new /p6 endpoint demonstrating CSRF protection with form submissions
- Implement constant-time CSRF token validation
- Improve template styling and consistency
- Add proper error handling and user feedback
- Update dependencies (subtle, serde) for security features

This example demonstrates proper CSRF protection in action, showing both successful and failed CSRF validations with clear user feedback.