### PR TITLE
Remove unused `gets` method from CacheStore trait and implementations

### DIFF
--- a/oauth2_passkey/src/storage/cache_store/memory.rs
+++ b/oauth2_passkey/src/storage/cache_store/memory.rs
@@ -50,22 +50,6 @@ impl CacheStore for InMemoryCacheStore {
         Ok(self.entry.get(&key).cloned())
     }
 
-    async fn gets(&self, prefix: &str, key: &str) -> Result<Vec<CacheData>, StorageError> {
-        let prefix_key = Self::make_key(prefix, key);
-        let matching_entries = self
-            .entry
-            .iter()
-            .filter_map(|(k, v)| {
-                if k.starts_with(&prefix_key) {
-                    Some(v.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        Ok(matching_entries)
-    }
-
     async fn remove(&mut self, prefix: &str, key: &str) -> Result<(), StorageError> {
         let key = Self::make_key(prefix, key);
         self.entry.remove(&key);

--- a/oauth2_passkey/src/storage/cache_store/redis.rs
+++ b/oauth2_passkey/src/storage/cache_store/redis.rs
@@ -60,24 +60,6 @@ impl CacheStore for RedisCacheStore {
         }
     }
 
-    async fn gets(&self, prefix: &str, key: &str) -> Result<Vec<CacheData>, StorageError> {
-        let mut conn = self.client.get_multiplexed_async_connection().await?;
-
-        let key = Self::make_key(prefix, key);
-        let keys: Vec<String> = conn.keys(&key).await?;
-
-        let mut results = Vec::new();
-        for key in keys {
-            let value: Option<String> = conn.get(&key).await?;
-
-            if let Some(v) = value {
-                let data: CacheData = serde_json::from_str(&v)?;
-                results.push(data);
-            }
-        }
-        Ok(results)
-    }
-
     async fn remove(&mut self, prefix: &str, key: &str) -> Result<(), StorageError> {
         let mut conn = self.client.get_multiplexed_async_connection().await?;
 

--- a/oauth2_passkey/src/storage/cache_store/types.rs
+++ b/oauth2_passkey/src/storage/cache_store/types.rs
@@ -33,9 +33,6 @@ pub(crate) trait CacheStore: Send + Sync + 'static {
     /// Get a token from the store.
     async fn get(&self, prefix: &str, key: &str) -> Result<Option<CacheData>, StorageError>;
 
-    /// Gets multiple tokens from the store.
-    async fn gets(&self, prefix: &str, key: &str) -> Result<Vec<CacheData>, StorageError>;
-
     /// Remove a token from the store.
     async fn remove(&mut self, prefix: &str, key: &str) -> Result<(), StorageError>;
 }


### PR DESCRIPTION
This commit removes the unused `gets` method from the CacheStore trait and its implementations in InMemoryCacheStore and RedisCacheStore. This simplifies the API by removing functionality that isn't needed by the codebase, following the principle of keeping the code as simple as possible.