### PR TITLE
fix(cargo-release): remove invalid dependencies section from workspac…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,3 @@ sign-tag = false
 push = false
 publish = false  # We'll control publishing manually or per-crate
 tag = false  # Don't tag at workspace level
-
-# Define publishing order: oauth2-passkey first, then oauth2-passkey-axum
-[[workspace.metadata.release.dependencies]]
-name = "oauth2-passkey"
-version = "workspace"
-
-[[workspace.metadata.release.dependencies]]
-name = "oauth2-passkey-axum"
-version = "workspace"
-depends = ["oauth2-passkey"]


### PR DESCRIPTION
…e.metadata.release

The dependencies key is not supported by cargo-release and caused TOML parse errors. Publishing order will be inferred from crate dependencies.