### PR TITLE
feat(release): Add logic to skip publishing already published versions

### DIFF
--- a/utils/release.sh
+++ b/utils/release.sh
@@ -135,18 +135,26 @@ if [ "$DRY_RUN" = false ]; then
     }
 
     echo "🎯 Step 1: Releasing oauth2-passkey $VERSION"
-    cargo publish -p oauth2-passkey || {
-        echo "❌ Failed to publish oauth2-passkey"
-        exit 1
-    }
+    if cargo search "oauth2-passkey" | grep -q "^oauth2-passkey.*$VERSION"; then
+        echo "✅ oauth2-passkey $VERSION is already published. Skipping."
+    else
+        cargo publish -p oauth2-passkey || {
+            echo "❌ Failed to publish oauth2-passkey"
+            exit 1
+        }
+    fi
 
     wait_for_crates_io "oauth2-passkey" "$VERSION"
 
     echo "🎯 Step 3: Releasing oauth2-passkey-axum $VERSION"
-    cargo publish -p oauth2-passkey-axum || {
-        echo "❌ Failed to publish oauth2-passkey-axum"
-        exit 1
-    }
+    if cargo search "oauth2-passkey-axum" | grep -q "^oauth2-passkey-axum.*$VERSION"; then
+        echo "✅ oauth2-passkey-axum $VERSION is already published. Skipping."
+    else
+        cargo publish -p oauth2-passkey-axum || {
+            echo "❌ Failed to publish oauth2-passkey-axum"
+            exit 1
+        }
+    fi
 
     update_tag "$VERSION"
 else


### PR DESCRIPTION
- Updated `utils/release.sh` to check if `oauth2-passkey` and `oauth2-passkey-axum` are already published before attempting to publish.
- Ensures the release process avoids redundant publishing steps and improves efficiency.
- Added conditional checks using `cargo search` to verify the published status of each crate.