### PR TITLE
Improve dependency management and bump to 0.1.4-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,37 +10,50 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4-dev"
 edition = "2024"
 
 [workspace.dependencies]
-# For development: use local paths
-oauth2-passkey-axum = { path = "./oauth2_passkey_axum" }
-oauth2-passkey = { path = "./oauth2_passkey" }
-
-# For publishing: uncomment these and comment out the path versions above
-#oauth2-passkey-axum = "0.1"
-#oauth2-passkey = "0.1"
-
+# Common packages
+askama = { version = "0.14.0" }
 async-trait = "0.1.88"
 axum = { version = "0.8", features = ["http2", "macros", "multipart"] }
-dotenvy = "0.15.7"
-
-http = "1.3.1"
-headers = "0.4.1"
-
-tokio = { version = "1.46", features = ["bytes", "fs", "io-std", "macros", "parking_lot", "rt-multi-thread", "signal-hook-registry", "socket2", "sync", "time", "tracing"] }
-rustls = { version = "0.23.29", features = ["ring"] }
 axum-core = "0.5.2"
 axum-extra = { version = "0.10.1", features = ["typed-header"] }
 chrono = { version = "0.4.41", features = ["serde"] }
-chrono-tz = "0.10.3"
-
-tracing = "0.1.41"
-thiserror = "2.0.12"
-serde_json = "1.0.140"
+chrono-tz = "0.10.4"
+dotenvy = "0.15.7"
+headers = "0.4.1"
+http = "1.3.1"
+rustls = { version = "0.23.29", features = ["ring"] }
 serde = { version = "1.0.219", features = ["derive"] }
-uuid = { version = "1.17", features = ["v4"] }
-urlencoding = "2.1.3"
-
+serde_json = "1.0.140"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "chrono", "json", "uuid"] }
+subtle = "2.6"
+thiserror = "2.0.12"
+tokio = { version = "1.46", features = ["bytes", "fs", "io-std", "macros", "parking_lot", "rt-multi-thread", "signal-hook-registry", "socket2", "sync", "time", "tracing"] }
+tracing = "0.1.41"
+urlencoding = "2.1.3"
+uuid = { version = "1.17", features = ["v4"] }
+
+### For oauth2_passkey_axum
+
+### For oauth2_passkey
+base64 = "0.22.1"
+ciborium = { version = "0.2.2", features = ["std"] }
+hmac = "0.12.1"
+jsonwebtoken = "9.3.1"
+oid-registry = "0.8.1"
+proptest = "1.7.0"
+redis = { version = "0.32.3", features = ["tokio-comp"] }
+reqwest = { version = "0.12.22", features = ["json"] }
+ring = { version = "0.17.14", features = ["std"] }
+serial_test = "3.2.0"
+sha2 = "0.10.9"
+url = "2.5.4"
+webpki = { version = "0.22.4", features = ["std"] }
+x509-parser = { version = "0.17.0", features = ["validate", "verify"] }
+
+### For demo-apps
+axum-server = { version = "0.7.2", features = ["tls-rustls"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/demo-both/Cargo.toml
+++ b/demo-both/Cargo.toml
@@ -4,18 +4,17 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-askama = { version = "0.14.0" }
-axum-server = { version = "0.7.2", features = ["tls-rustls"] }
-dotenvy = { workspace = true }
-http = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-axum = { workspace = true }
-tokio = { workspace = true }
-rustls = { workspace = true }
-
-oauth2-passkey-axum = { workspace = true }
+oauth2-passkey-axum = { path = "../oauth2_passkey_axum" }
 #oauth2-passkey-axum = "0.1"
 
-subtle = "2.6"
-serde = { version = "1.0", features = ["derive"] }
+askama = { workspace = true }
+axum = { workspace = true }
+axum-server = { workspace = true }
+dotenvy = { workspace = true }
+http = { workspace = true }
+rustls = { workspace = true }
+serde = { workspace = true }
+subtle = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/demo-oauth2/Cargo.toml
+++ b/demo-oauth2/Cargo.toml
@@ -4,17 +4,15 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-askama = { version = "0.14.0" }
-axum = { version = "0.8", features = ["macros"] }
-axum-server = { version = "0.7.2", features = ["tls-rustls"] }
+oauth2-passkey-axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
+#oauth2-passkey-axum = { version = "0.1", default-features = false, features = [] }
+
+askama = { workspace = true }
+axum = { workspace = true }
+axum-server = { workspace = true }
 dotenvy = { workspace = true }
 http = { workspace = true }
-tokio = { version = "1.46.1", features = ["full"] }
-tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 rustls = { workspace = true }
-
-oauth2-passkey-axum = { workspace = true }
-#oauth2-passkey-axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
-
-#oauth2-passkey-axum = { version = "0.1", default-features = false, features = [] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/demo-passkey/Cargo.toml
+++ b/demo-passkey/Cargo.toml
@@ -4,18 +4,16 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-askama = "0.14.0"
+oauth2-passkey-axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
+#oauth2-passkey-axum = { version = "0.1", default-features = false, features = [] }
+
+askama = { workspace = true }
 axum = { workspace = true }
 axum-core = { workspace = true }
-axum-server = { version = "0.7.2", features = ["tls-rustls"] }
-tokio = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-rustls = { workspace = true }
+axum-server = { workspace = true }
 dotenvy = { workspace = true }
 http = { workspace = true }
-
-#oauth2-passkey-axum = { path = "../oauth2_passkey_axum", default-features = false, features = [] }
-oauth2-passkey-axum = { workspace = true }
-
-#oauth2-passkey-axum = { version = "0.1", default-features = false, features = [] }
+rustls = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/oauth2_passkey/Cargo.toml
+++ b/oauth2_passkey/Cargo.toml
@@ -14,33 +14,31 @@ readme = "README.md"
 
 [dependencies]
 async-trait = { workspace = true }
-chrono.workspace = true
-headers.workspace = true
-http.workspace = true
-serde_json.workspace = true
-serde.workspace = true
-sqlx.workspace = true
-thiserror.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-uuid.workspace = true
-
-dotenvy = "0.15.7"
-hmac = "0.12.1"
-sha2 = "0.10.9"
-base64 = "0.22.1"
-
-ciborium = { version = "0.2.2", features = ["std"] }
-oid-registry = "0.8.1"
-redis = { version = "0.32.3", features = ["tokio-comp"] }
-ring = { version = "0.17.14", features = ["std"] }
-webpki = { version = "0.22.4", features = ["std"] }
-x509-parser = { version = "0.17.0", features = ["validate", "verify"] }
-jsonwebtoken = "9.3.1"
-reqwest = { version = "0.12.22", features = ["json"] }
-url = "2.5.4"
-subtle = "2.6"
+base64 = { workspace = true }
+chrono = { workspace = true }
+ciborium = { workspace = true }
+dotenvy = { workspace = true }
+headers = { workspace = true }
+hmac = { workspace = true }
+http = { workspace = true }
+jsonwebtoken = { workspace = true }
+oid-registry = { workspace = true }
+redis = { workspace = true }
+reqwest = { workspace = true }
+ring = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+sqlx = { workspace = true }
+subtle = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+webpki = { workspace = true }
+x509-parser = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3.2.0"
-proptest = "1.7.0"
+serial_test = { workspace = true }
+proptest = { workspace = true }

--- a/oauth2_passkey_axum/Cargo.toml
+++ b/oauth2_passkey_axum/Cargo.toml
@@ -18,22 +18,22 @@ admin-ui = []
 user-ui = []
 
 [dependencies]
-askama = { version = "0.14.0" }
-http = { workspace = true }
-tracing = { workspace = true }
-
 # Changed from workspace dependency to published crate version
-oauth2-passkey = "0.1.3"
+oauth2-passkey = { path = "../oauth2_passkey" }
+#oauth2-passkey = { version = "0.1.x" }
 
+askama = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-urlencoding = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
-subtle = "2.6"
+http = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+subtle = { workspace = true }
+tracing = { workspace = true }
+urlencoding = { workspace = true }
 
 [dev-dependencies]
+dotenvy = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
-dotenvy = "0.15.7"


### PR DESCRIPTION
- Standardize all crates to use { workspace = true } syntax
- Sort dependencies alphabetically across all Cargo.toml files
- Reorganize workspace dependencies into logical sections
- Update chrono-tz from 0.10.3 to 0.10.4
- Switch to path dependencies for local development