### PR TITLE
  fix: WebAuthn counter decreasing issue in CI/parallel test environm…

### DIFF
--- a/docs/TestKeyPairGeneration.md
+++ b/docs/TestKeyPairGeneration.md
@@ -145,7 +145,7 @@ The key pair enables proper WebAuthn signature verification in tests:
 ### Common Issues Fixed
 
 1. **"Signature verification failed"**: Solved by using matching key pairs
-2. **"Counter value decreased"**: Fixed by using timestamp-based counters in mock authentication
+2. **"Counter value decreased"**: Fixed by using atomic counter with timestamp base to ensure monotonic increase in parallel tests
 3. **"Key format mismatch"**: Resolved by proper PKCS#8 → WebAuthn format conversion
 
 ### Verification Commands

--- a/docs/TestKeyPairGeneration.md
+++ b/docs/TestKeyPairGeneration.md
@@ -145,7 +145,7 @@ The key pair enables proper WebAuthn signature verification in tests:
 ### Common Issues Fixed
 
 1. **"Signature verification failed"**: Solved by using matching key pairs
-2. **"Counter value decreased"**: Fixed by using atomic counter with timestamp base to ensure monotonic increase in parallel tests
+2. **"Counter value decreased"**: Fixed by using atomic `fetch_max` with timestamp base to ensure robust monotonic increase in parallel tests
 3. **"Key format mismatch"**: Resolved by proper PKCS#8 → WebAuthn format conversion
 
 ### Verification Commands

--- a/oauth2_passkey/tests/common/fixtures.rs
+++ b/oauth2_passkey/tests/common/fixtures.rs
@@ -742,7 +742,9 @@ impl MockWebAuthnCredentials {
         // Note: fetch_add returns the OLD value, so we add 1 to get the NEW value
         // Use wrapping_add to handle potential u32 overflow gracefully (though unlikely in tests)
         // Use Relaxed ordering for consistency and performance - only atomicity needed, not strict ordering
-        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+        let counter_value = COUNTER_BASE
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
         auth_data.extend_from_slice(&counter_value.to_be_bytes());
 
         // No attested credential data for authentication

--- a/oauth2_passkey/tests/common/fixtures.rs
+++ b/oauth2_passkey/tests/common/fixtures.rs
@@ -741,7 +741,8 @@ impl MockWebAuthnCredentials {
         // Increment and get next counter value - guaranteed to be unique and increasing
         // Note: fetch_add returns the OLD value, so we add 1 to get the NEW value
         // Use wrapping_add to handle potential u32 overflow gracefully (though unlikely in tests)
-        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
+        // Use Relaxed ordering for consistency and performance - only atomicity needed, not strict ordering
+        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
         auth_data.extend_from_slice(&counter_value.to_be_bytes());
 
         // No attested credential data for authentication

--- a/oauth2_passkey/tests/common/fixtures.rs
+++ b/oauth2_passkey/tests/common/fixtures.rs
@@ -738,7 +738,8 @@ impl MockWebAuthnCredentials {
         COUNTER_BASE.fetch_max(timestamp_base, Ordering::SeqCst);
 
         // Increment and get next counter value - guaranteed to be unique and increasing
-        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::SeqCst);
+        // Note: fetch_add returns the OLD value, so we add 1 to get the NEW value
+        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::SeqCst) + 1;
         auth_data.extend_from_slice(&counter_value.to_be_bytes());
 
         // No attested credential data for authentication

--- a/oauth2_passkey/tests/common/fixtures.rs
+++ b/oauth2_passkey/tests/common/fixtures.rs
@@ -742,9 +742,7 @@ impl MockWebAuthnCredentials {
         // Note: fetch_add returns the OLD value, so we add 1 to get the NEW value
         // Use wrapping_add to handle potential u32 overflow gracefully (though unlikely in tests)
         // Use Relaxed ordering for consistency and performance - only atomicity needed, not strict ordering
-        let counter_value = COUNTER_BASE
-            .fetch_add(1, Ordering::Relaxed)
-            .saturating_add(1);
+        let counter_value = COUNTER_BASE.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
         auth_data.extend_from_slice(&counter_value.to_be_bytes());
 
         // No attested credential data for authentication


### PR DESCRIPTION
…ents

  - Replace timestamp-based counter with atomic counter + timestamp base
  - Ensures monotonic increase in rapid succession scenarios
  - Fixes "Counter value decreased" errors in CI environments
  - Update documentation to reflect atomic counter solution
  - Clean whitespace in documentation files

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>