### PR TITLE
refactor(axum): move /info and /csrf_token to default.rs

### DIFF
--- a/.claude/issues/completed/2026-01-30-move-info-csrf-endpoints.md
+++ b/.claude/issues/completed/2026-01-30-move-info-csrf-endpoints.md
@@ -2,7 +2,7 @@
 
 ## ID: 2026-01-30-01
 
-## Status: open
+## Status: completed
 
 ## Priority: medium
 
@@ -35,3 +35,8 @@ Implementation steps:
 
 ## Resolution
 
+Completed on 2026-01-30.
+
+- Moved `/info` and `/csrf_token` handlers from `optional.rs` to `default.rs`
+- These endpoints are now always available regardless of `user-ui` feature flag
+- Cleaned up unused imports in `optional.rs`

--- a/oauth2_passkey_axum/src/router.rs
+++ b/oauth2_passkey_axum/src/router.rs
@@ -45,7 +45,7 @@ pub fn oauth2_passkey_router() -> Router {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use axum::Router;
 /// use oauth2_passkey_axum::oauth2_passkey_full_router;
 ///

--- a/oauth2_passkey_axum/src/user/default.rs
+++ b/oauth2_passkey_axum/src/user/default.rs
@@ -19,6 +19,8 @@ use crate::session::AuthUser;
 /// Create a router for the user summary endpoints
 pub(crate) fn router() -> Router<()> {
     Router::new()
+        .route("/info", get(user_info))
+        .route("/csrf_token", get(csrf_token))
         .route("/logout", get(logout))
         .route("/delete", delete(delete_user_account_handler))
         .route("/update", put(update_user_account_handler))
@@ -54,6 +56,38 @@ async fn logout(
             }
         },
     }
+}
+
+/// Return basic user information as JSON for the client-side JavaScript
+///
+/// This endpoint provides the authenticated user's basic information (id, name, display_name)
+/// to be used by client-side JavaScript for pre-filling forms or displaying user information.
+async fn user_info(auth_user: Option<AuthUser>) -> Result<Json<Value>, (StatusCode, String)> {
+    match auth_user {
+        Some(user) => {
+            // Return user information as JSON
+            let user_data = json!({
+                "id": user.id,
+                "account": user.account,
+                "label": user.label,
+            });
+
+            Ok(Json(user_data))
+        }
+        None => {
+            // Return a 401 Unauthorized if no user is authenticated
+            Err((StatusCode::UNAUTHORIZED, "Not authenticated".to_string()))
+        }
+    }
+}
+
+/// Return the CSRF token for the authenticated user
+///
+/// This endpoint provides the CSRF token for the authenticated user to be used by the client-side JavaScript.
+async fn csrf_token(auth_user: AuthUser) -> Result<Json<Value>, (StatusCode, String)> {
+    Ok(Json(json!({
+        "csrf_token": auth_user.csrf_token
+    })))
 }
 
 /// Request payload for updating user account information

--- a/oauth2_passkey_axum/src/user/optional.rs
+++ b/oauth2_passkey_axum/src/user/optional.rs
@@ -2,7 +2,7 @@ use askama::Template;
 use axum::{
     Router,
     http::{StatusCode, header::CONTENT_TYPE},
-    response::{Html, IntoResponse, Json, Redirect, Response},
+    response::{Html, IntoResponse, Redirect, Response},
     routing::get,
 };
 use chrono::{DateTime, Utc};
@@ -11,8 +11,6 @@ use std::{
     collections::{HashMap, HashSet},
     sync::LazyLock,
 };
-
-use serde_json::{Value, json};
 
 use oauth2_passkey::{
     AuthenticatorInfo, O2P_ROUTE_PREFIX, UserId, generate_page_session_token,
@@ -24,8 +22,6 @@ use crate::session::AuthUser;
 
 pub(crate) fn router() -> Router<()> {
     Router::new()
-        .route("/info", get(user_info))
-        .route("/csrf_token", get(csrf_token))
         .route("/login", get(login))
         .route("/account", get(user_account))
         .route("/account.js", get(serve_account_js))
@@ -143,38 +139,6 @@ impl UserAccountTemplate {
             custom_css_url,
         }
     }
-}
-
-/// Return basic user information as JSON for the client-side JavaScript
-///
-/// This endpoint provides the authenticated user's basic information (id, name, display_name)
-/// to be used by client-side JavaScript for pre-filling forms or displaying user information.
-async fn user_info(auth_user: Option<AuthUser>) -> Result<Json<Value>, (StatusCode, String)> {
-    match auth_user {
-        Some(user) => {
-            // Return user information as JSON
-            let user_data = json!({
-                "id": user.id,
-                "account": user.account,
-                "label": user.label,
-            });
-
-            Ok(Json(user_data))
-        }
-        None => {
-            // Return a 401 Unauthorized if no user is authenticated
-            Err((StatusCode::UNAUTHORIZED, "Not authenticated".to_string()))
-        }
-    }
-}
-
-/// Return the CSRF token for the authenticated user
-///
-/// This endpoint provides the CSRF token for the authenticated user to be used by the client-side JavaScript.
-async fn csrf_token(auth_user: AuthUser) -> Result<Json<Value>, (StatusCode, String)> {
-    Ok(Json(json!({
-        "csrf_token": auth_user.csrf_token
-    })))
 }
 
 /// Display the user account management page with user info, passkey credentials, and OAuth2 accounts


### PR DESCRIPTION
These JSON API endpoints should be always available, not gated behind the user-ui feature flag. Custom page developers need them even when not using the built-in login/account UI pages.

- Move user_info handler from optional.rs to default.rs
- Move csrf_token handler from optional.rs to default.rs
- Clean up unused imports in optional.rs
- Change doctest from ignore to no_run for better coverage

Closes: 2026-01-30-01