### PR TITLE
feat(passkey): change PASSKEY_USER_HANDLE_UNIQUE default to false

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,27 +6,26 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (11)
+### Open (9)
 
-| ID | Priority | Title |
-|----|----------|-------|
-| `2026-01-23-01` | medium | [Bearer Token Authentication Support](open/2026-01-23-bearer-token-support.md) |
-| `2026-01-29-01` | medium | [Change PASSKEY_USER_HANDLE_UNIQUE default to false](open/2026-01-29-change-user-handle-default.md) |
-| `2026-01-30-01` | medium | [Move /info and /csrf_token to default.rs](open/2026-01-30-move-info-csrf-endpoints.md) |
-| `2026-01-30-02` | medium | [Admin Force Logout Feature](open/2026-01-30-admin-force-logout.md) |
-| `2026-01-30-03` | medium | [Admin Login History View](open/2026-01-30-admin-login-history.md) |
-| `2026-01-30-04` | medium | [Update README.md with Links and Demo Info](open/2026-01-30-readme-links-update.md) |
-| `2026-01-30-05` | medium | [getClientCapabilities Feature Detection](open/2026-01-30-client-capabilities-detection.md) |
-| `2026-01-30-06` | medium | [Passkey Endpoint (.well-known) Support](open/2026-01-30-passkey-endpoint-wellknown.md) |
-| `2026-01-30-07` | medium | [Passkey Registration Promotion After Login](open/2026-01-30-conditional-creation.md) |
-| `2026-01-29-03` | low | [Create Terminology/Glossary Document](open/2026-01-29-terminology-document.md) |
-| `2026-01-30-08` | low | [Demo Site Deployment (Fly.io)](open/2026-01-30-demo-site-deployment.md) |
+| ID | Priority | Difficulty | Title |
+|----|----------|------------|-------|
+| `2026-01-23-01` | medium | large | [Bearer Token Authentication Support](open/2026-01-23-bearer-token-support.md) |
+| `2026-01-30-02` | medium | medium | [Admin Force Logout Feature](open/2026-01-30-admin-force-logout.md) |
+| `2026-01-30-03` | medium | large | [Admin Login History View](open/2026-01-30-admin-login-history.md) |
+| `2026-01-30-04` | medium | small | [Update README.md with Links and Demo Info](open/2026-01-30-readme-links-update.md) |
+| `2026-01-30-05` | medium | small | [getClientCapabilities Feature Detection](open/2026-01-30-client-capabilities-detection.md) |
+| `2026-01-30-06` | medium | small | [Passkey Endpoint (.well-known) Support](open/2026-01-30-passkey-endpoint-wellknown.md) |
+| `2026-01-30-07` | medium | large | [Passkey Registration Promotion After Login](open/2026-01-30-conditional-creation.md) |
+| `2026-01-29-03` | low | small | [Create Terminology/Glossary Document](open/2026-01-29-terminology-document.md) |
+| `2026-01-30-08` | low | medium | [Demo Site Deployment (Fly.io)](open/2026-01-30-demo-site-deployment.md) |
 
-### Completed (13)
+### Completed (15)
 
 | ID | Title |
 |----|-------|
 | `2025-01-23-01` | [CI/CD Documentation](completed/2025-01-23-ci-cd-documentation.md) |
+| `2026-01-29-01` | [Change PASSKEY_USER_HANDLE_UNIQUE default to false](completed/2026-01-29-change-user-handle-default.md) |
 | `2025-01-23-02` | [CSRF Documentation & Snapshot System](completed/2025-01-23-csrf-docs-snapshot-system.md) |
 | `2026-01-24-02` | [Demo Apps Implementation](completed/2026-01-24-demo-apps-implementation.md) |
 | `2026-01-26-01` | [Demo Apps Database Configuration](completed/2026-01-26-demo-apps-db-config.md) |
@@ -39,6 +38,7 @@ This directory contains issue/task tracking files for the project.
 | `2026-01-28-03` | [Fix Windows Hello TPM Attestation (RS1)](completed/2026-01-28-tpm-rs1-attestation-fix.md) |
 | `2026-01-29-02` | [Filter remaining_credential_ids by user_handle](completed/2026-01-29-filter-remaining-credentials.md) |
 | `2026-01-29-04` | [Review SESSION_CONFLICT_POLICY Default](completed/2026-01-29-session-conflict-policy-review.md) |
+| `2026-01-30-01` | [Move /info and /csrf_token to default.rs](completed/2026-01-30-move-info-csrf-endpoints.md) |
 
 ### Deferred (1)
 
@@ -89,6 +89,8 @@ Example: `2026-01-30-01`, `2026-01-30-02`
 ## Status: open | completed | wontfix | deferred
 
 ## Priority: high | medium | low
+
+## Difficulty: small | medium | large
 
 ## Description
 

--- a/.claude/issues/completed/2026-01-29-change-user-handle-default.md
+++ b/.claude/issues/completed/2026-01-29-change-user-handle-default.md
@@ -2,9 +2,11 @@
 
 ## ID: 2026-01-29-01
 
-## Status: open
+## Status: completed
 
 ## Priority: medium
+
+## Difficulty: small
 
 ## Description
 
@@ -12,9 +14,12 @@ Change `PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL` default from `true` to 
 
 ## Related Files
 
-- `oauth2_passkey/src/env_var.rs` - Change default value
+- `oauth2_passkey/src/passkey/config.rs` - Change default value
 - `docs/src/webauthn/user-handle-and-signal-api.md` - Update documentation
+- `docs/src/integration/configuration.md` - Update config reference
+- `docs/src/integration/passkey.md` - Update config table
 - `dot.env.example` - Update example config
+- `CHANGELOG.md` - Document breaking change
 
 ## Notes
 
@@ -45,29 +50,16 @@ From session 2026-01-29:
 - Migration guide in release notes
 - Prominent warning about credential replacement
 
-**Implementation Plan**:
-
-Step 1: Change default value in `oauth2_passkey/src/env_var.rs`:
-```rust
-// Before
-env_var_bool("PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL", true)
-// After
-env_var_bool("PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL", false)
-```
-
-Step 2: Update documentation table in `user-handle-and-signal-api.md`:
-```markdown
-| `false` (default) | Shared per user | One |
-| `true` | Unique per credential | Unlimited |
-```
-
-Step 3: Update `dot.env.example`:
-```bash
-# Uncomment to allow multiple credentials per authenticator type
-# PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=true
-```
-
-Step 4: Add migration note to CHANGELOG/release notes
-
 ## Resolution
 
+Implemented in branch `dev-2026-01-29-01`:
+
+1. Changed default from `true` to `false` in `oauth2_passkey/src/passkey/config.rs`
+2. Updated all documentation to reflect new default:
+   - `docs/src/webauthn/user-handle-and-signal-api.md`
+   - `docs/src/integration/configuration.md`
+   - `docs/src/integration/passkey.md`
+3. Updated `dot.env.example` with new default and clarified comments
+4. Added BREAKING CHANGE entry in `CHANGELOG.md`
+
+All tests pass. Existing credentials are not affected; only newly registered credentials use the new default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: Changed `PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL` default from `true` to `false`
+  - New behavior: All credentials for the same user share a single `user_handle` (standard WebAuthn practice)
+  - Old behavior: Each credential had a unique `user_handle`
+  - Existing credentials are not affected; only newly registered credentials use the new default
 - Signal API calls now conditionally execute based on `PASSKEY_SIGNAL_API_MODE` setting
 - Passkey registration username prefill changed from `#N` sequential numbering to `@YYYYMMDD` date suffix
 

--- a/docs/src/integration/configuration.md
+++ b/docs/src/integration/configuration.md
@@ -275,13 +275,13 @@ Controls user handle generation strategy.
 
 | Value | Behavior |
 |-------|----------|
-| `true` | Generate unique user_handle per credential (allows multiple credentials per user per site) |
 | `false` | Use single user_handle for all credentials for a user (limits to one credential per user per site) |
+| `true` | Generate unique user_handle per credential (allows multiple credentials per user per site) |
 
-- **Default**: `true`
+- **Default**: `false`
 
 ```bash
-PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=true
+PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=false
 ```
 
 **Note**: Password managers typically allow only one credential per user identifier. Set to `true` if users need multiple passkeys.

--- a/docs/src/integration/passkey.md
+++ b/docs/src/integration/passkey.md
@@ -656,7 +656,7 @@ let app = Router::new()
 | `PASSKEY_RESIDENT_KEY` | `required` | Resident key requirement (`required`, `preferred`, `discouraged`) |
 | `PASSKEY_REQUIRE_RESIDENT_KEY` | `true` | Require resident/discoverable credentials |
 | `PASSKEY_USER_VERIFICATION` | `discouraged` | User verification (`required`, `preferred`, `discouraged`) |
-| `PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL` | `true` | Generate unique user handle per credential |
+| `PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL` | `false` | Use single user handle per user (set to `true` for unique per credential) |
 | `PASSKEY_USER_ACCOUNT_FIELD` | `name` | Field to use for user account (`name` or `display_name`) |
 | `PASSKEY_USER_LABEL_FIELD` | `display_name` | Field to use for user label (`name` or `display_name`) |
 

--- a/docs/src/webauthn/user-handle-and-signal-api.md
+++ b/docs/src/webauthn/user-handle-and-signal-api.md
@@ -50,14 +50,14 @@ This library provides an option to generate a unique user handle for each creden
 ### Configuration
 
 ```bash
-# Default: true
-PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=true
+# Default: false
+PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=false
 ```
 
-| Value            | `user_handle`         | Credentials per authenticator |
-|------------------|-----------------------|-------------------------------|
-| `true` (default) | Unique per credential | Unlimited                     |
-| `false`          | Shared per user       | One                           |
+| Value             | `user_handle`         | Credentials per authenticator |
+|-------------------|--------------------------------------|-------------------------------|
+| `false` (default) | Shared per user                      | One                           |
+| `true`            | Unique per credential                | Unlimited                     |
 
 ### When `true` (Unique Per Credential)
 

--- a/dot.env.example
+++ b/dot.env.example
@@ -162,11 +162,11 @@ O2P_ROUTE_PREFIX='/o2p'
 # Default: 'discouraged' (Options: 'required', 'preferred', 'discouraged')
 #PASSKEY_USER_VERIFICATION='discouraged'
 
-# Default: true (Options: true, false)
-#PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=true
+# Default: false (Options: true, false)
+#PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL=false
 
 # Note on PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL: Password managers typically allow only one credential per user identifier.
-# When false: Uses single user_handle for all credentials for a user (limits each user to have one credential per site)
+# When false (default): Uses single user_handle for all credentials for a user (limits each user to have one credential per site)
 # When true: Generates unique user_handle per credential (allows each user to have multiple credentials per site)
 
 # Signal API mode for credential synchronization with authenticators (SERVER-SIDE ONLY)

--- a/oauth2_passkey/src/passkey/config.rs
+++ b/oauth2_passkey/src/passkey/config.rs
@@ -114,6 +114,6 @@ pub(super) static PASSKEY_USER_VERIFICATION: LazyLock<String> = LazyLock::new(||
 pub(super) static PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL: LazyLock<bool> =
     LazyLock::new(|| {
         env::var("PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL")
-            .map(|v| v.parse::<bool>().unwrap_or(true))
-            .unwrap_or(true)
+            .map(|v| v.parse::<bool>().unwrap_or(false))
+            .unwrap_or(false)
     });


### PR DESCRIPTION
BREAKING CHANGE: The default value of PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL has been changed from true to false.

- New behavior: All credentials for the same user share a single user_handle (standard WebAuthn practice, better Signal API compatibility)
- Old behavior: Each credential had a unique user_handle
- Existing credentials are not affected; only newly registered credentials use the new default

Updated files:
- oauth2_passkey/src/passkey/config.rs: Change default value
- docs/src/webauthn/user-handle-and-signal-api.md: Update documentation
- docs/src/integration/configuration.md: Update config reference
- docs/src/integration/passkey.md: Update config table
- dot.env.example: Update example and comments
- CHANGELOG.md: Document breaking change
- .claude/issues/: Move issue 2026-01-29-01 to completed