### PR TITLE
docs(deploy): add roles/logging.viewer for Cloud Build log streaming

### DIFF
--- a/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
+++ b/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
@@ -63,6 +63,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/artifactregistry.writer"
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${SA_EMAIL}" --role="roles/logging.viewer"
 
 # 3. Generate JSON key
 gcloud iam service-accounts keys create sa-key.json \

--- a/demo-live/DEPLOY.md
+++ b/demo-live/DEPLOY.md
@@ -198,6 +198,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/artifactregistry.writer"
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:${SA_EMAIL}" --role="roles/logging.viewer"
 
 # 3. Generate JSON key
 gcloud iam service-accounts keys create sa-key.json \


### PR DESCRIPTION
Without this role, gcloud builds submit cannot stream build logs, causing the command to exit with error even when the build succeeds.