### PR TITLE
fix(ci): use --suppress-logs for Cloud Build in deploy workflow

### DIFF
--- a/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
+++ b/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
@@ -63,8 +63,6 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/artifactregistry.writer"
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member="serviceAccount:${SA_EMAIL}" --role="roles/logging.viewer"
 
 # 3. Generate JSON key
 gcloud iam service-accounts keys create sa-key.json \

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Build with Cloud Build
-        run: gcloud builds submit --config=demo-live/cloudbuild.yaml
+        run: gcloud builds submit --config=demo-live/cloudbuild.yaml --suppress-logs
 
       - name: Deploy to Cloud Run
         run: |

--- a/demo-live/DEPLOY.md
+++ b/demo-live/DEPLOY.md
@@ -198,8 +198,6 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/artifactregistry.writer"
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:${SA_EMAIL}" --role="roles/storage.admin"
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member="serviceAccount:${SA_EMAIL}" --role="roles/logging.viewer"
 
 # 3. Generate JSON key
 gcloud iam service-accounts keys create sa-key.json \


### PR DESCRIPTION
The SA lacks project-level Viewer role required for log streaming. Using --suppress-logs skips log streaming while still waiting for build completion and correctly reporting success/failure. Also removes ineffective roles/logging.viewer from docs.