### PR TITLE
fix(ci): use REGIONAL_USER_OWNED_BUCKET for Cloud Build log streaming

### DIFF
--- a/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
+++ b/.claude/issues/open/20260212-1200-github-actions-auto-deploy.md
@@ -182,4 +182,17 @@ Workflow auth changes to:
 - Decision: Create separate issue for auto-deploy
 - Reason: Clean separation of concerns; deployment issue can be closed as completed
 
+### 2026-02-12: Fix Cloud Build log streaming permission error
+
+- Context: `gcloud builds submit` in GitHub Actions failed with "This tool can only stream logs
+  if you are Viewer/Owner of the project". The SA has `cloudbuild.builds.editor` + `storage.admin`
+  but not project-level `roles/viewer`. Three attempts failed:
+  1. `roles/logging.viewer` - insufficient (default logs bucket is Cloud Storage, not Cloud Logging)
+  2. `--suppress-logs` - flag did not prevent the log streaming attempt
+  3. Granting `roles/viewer` was rejected as overly broad (read access to all project resources)
+- Decision: Add `defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET` to `cloudbuild.yaml`
+- Reason: Uses a user-owned regional bucket for build logs instead of the Google-managed default
+  bucket. The SA's existing `roles/storage.admin` covers read/write access to user-owned buckets,
+  eliminating the need for the broad `roles/viewer` role. Logs remain visible in GitHub Actions.
+
 ## Resolution

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -30,7 +30,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Build with Cloud Build
-        run: gcloud builds submit --config=demo-live/cloudbuild.yaml --suppress-logs
+        run: gcloud builds submit --config=demo-live/cloudbuild.yaml
 
       - name: Deploy to Cloud Run
         run: |

--- a/demo-live/cloudbuild.yaml
+++ b/demo-live/cloudbuild.yaml
@@ -9,3 +9,5 @@ steps:
       - '.'
 images:
   - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/demo/oauth2-passkey-demo'
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET


### PR DESCRIPTION
Default Cloud Build logs bucket requires project-level roles/viewer for log streaming. Use user-owned regional bucket instead, which works with the SA's existing roles/storage.admin. Also removes --suppress-logs flag which was ineffective.