### PR TITLE
fix: remove race-prone mock call tracking from passkey tests

### DIFF
--- a/oauth2_passkey_axum/src/passkey/promotion/tests.rs
+++ b/oauth2_passkey_axum/src/passkey/promotion/tests.rs
@@ -34,9 +34,6 @@ async fn test_promotion_includes_exclude_credentials() {
     // Initialize test environment
     let _ = crate::test_utils::env::origin();
 
-    // Reset mock tracking
-    core_mocks::reset_mock_calls();
-
     // Create a mock AuthUser
     let auth_user = mocks::mock_auth_user("test-user-id", "test@example.com");
 
@@ -68,12 +65,6 @@ async fn test_promotion_includes_exclude_credentials() {
     assert!(
         first["id"].is_string(),
         "id should be a string (credential_id)"
-    );
-
-    // Verify mock was called
-    assert!(
-        core_mocks::was_list_credentials_called(),
-        "list_credentials should be called to build excludeCredentials"
     );
 }
 

--- a/oauth2_passkey_axum/src/passkey/tests.rs
+++ b/oauth2_passkey_axum/src/passkey/tests.rs
@@ -15,9 +15,6 @@ async fn test_list_passkey_credentials_handler() {
     // Initialize test environment
     let _ = crate::test_utils::env::origin();
 
-    // Reset mock tracking
-    core_mocks::reset_mock_calls();
-
     // Create a mock AuthUser
     let auth_user = mocks::mock_auth_user("test-user-id", "test@example.com");
 
@@ -56,12 +53,6 @@ async fn test_list_passkey_credentials_handler() {
             panic!("Expected successful result with credentials, got error: {status} - {message}");
         }
     }
-
-    // Verify that our mock function was called
-    assert!(
-        core_mocks::was_list_credentials_called(),
-        "Mock list_credentials_core function was not called"
-    );
 }
 
 /// Test the update_passkey_credential handler with mocked dependencies

--- a/oauth2_passkey_axum/src/test_utils.rs
+++ b/oauth2_passkey_axum/src/test_utils.rs
@@ -90,9 +90,6 @@ pub mod mocks {
 /// Core function mocks for testing without external dependencies
 pub mod core_mocks {
     use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    static MOCK_LIST_CREDENTIALS_CALLED: AtomicBool = AtomicBool::new(false);
 
     /// Helper function to create a mock PasskeyCredential for testing
     fn create_mock_credential(
@@ -139,8 +136,6 @@ pub mod core_mocks {
         user_id: &str,
         _include_transports: bool,
     ) -> Result<Vec<PasskeyCredential>, oauth2_passkey::CoordinationError> {
-        MOCK_LIST_CREDENTIALS_CALLED.store(true, Ordering::SeqCst);
-
         // Create a mock credential
         let credential = create_mock_credential(user_id, "test-credential-id", "test-public-key");
 
@@ -163,16 +158,4 @@ pub mod core_mocks {
             "userVerification": "required"
         }))
     }
-
-    /// Check if mock_list_credentials_core was called
-    pub fn was_list_credentials_called() -> bool {
-        MOCK_LIST_CREDENTIALS_CALLED.load(Ordering::SeqCst)
-    }
-
-    /// Reset mock call tracking
-    pub fn reset_mock_calls() {
-        MOCK_LIST_CREDENTIALS_CALLED.store(false, Ordering::SeqCst);
-    }
-
-    // The mock_update_passkey_credential_core function is already defined above
 }


### PR DESCRIPTION
Two test files shared a global AtomicBool (MOCK_LIST_CREDENTIALS_CALLED) for tracking mock calls. When tests ran in parallel, one test's reset_mock_calls() could clear the flag between another test's mock call and assertion, causing sporadic failures under cargo-llvm-cov (CI Code Coverage) where LLVM instrumentation widens the race window.

The tracking was redundant -- both tests already call the mock directly and verify the return value. Removed reset_mock_calls(), was_list_credentials_called(), and the backing AtomicBool.