### PR TITLE
issue: triage 3 issues and update AAGUID collision approach

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (15)
+### Open (12)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -20,11 +20,8 @@ This directory contains issue/task tracking files for the project.
 | `2026-01-31-01` | low | medium | [Sequential Primary Keys Optimization](open/2026-01-31-sequential-pkey-optimization.md) |
 | `20260226-2030` | low | medium | [AAGUID-Based Credential Deletion Collision](open/20260226-2030-aaguid-credential-deletion-collision.md) |
 | `20260227-1703` | low | small | [Audit and Improve Silent Fallback Behavior for Optional Environment Variables](open/20260227-1703-env-var-silent-fallback-audit.md) |
-| `20260226-2023` | low | small | [Authentication Method Tracking in Session](open/20260226-2023-auth-method-tracking-in-session.md) |
-| `20260226-2022` | low | large | [OAuth2 Token Storage](open/20260226-2022-oauth2-token-storage.md) |
 | `20260226-1814` | low | large | [Device Bound Session Credentials (DBSC) Support](open/20260226-1814-device-bound-session-credentials.md) |
 | `20260226-2025` | low | large | [E2E Tests](open/20260226-2025-e2e-tests.md) |
-| `20260226-2026` | low | large | [UI Improvements](open/20260226-2026-ui-improvements.md) |
 
 ### Completed (43)
 
@@ -74,17 +71,20 @@ This directory contains issue/task tracking files for the project.
 | `2026-01-30-09` | [Cross-Origin Same-Site Demo (Pattern 2)](completed/2026-01-30-cross-origin-same-site-demo.md) |
 | `2026-01-31-02` | [Remove HTTPS Support from Demo Apps](completed/2026-01-31-demo-remove-https.md) |
 
-### Wontfix (2)
+### Wontfix (4)
 
 | ID | Title |
 |----|-------|
+| `20260226-2023` | [Authentication Method Tracking in Session](wontfix/20260226-2023-auth-method-tracking-in-session.md) |
+| `20260226-2026` | [UI Improvements](wontfix/20260226-2026-ui-improvements.md) |
 | `20260212-0235` | [Standalone Demo Repository](wontfix/20260212-0235-standalone-demo-repository.md) |
 | `20260213-1500` | [Remove seq=1 from has_admin_privileges()](wontfix/20260213-remove-seq1-from-has-admin-privileges.md) |
 
-### Deferred (3)
+### Deferred (4)
 
 | ID | Title |
 |----|-------|
+| `20260226-2022` | [OAuth2 Token Storage](deferred/20260226-2022-oauth2-token-storage.md) |
 | `2026-01-23-01` | [Bearer Token Authentication Support](deferred/2026-01-23-bearer-token-support.md) |
 | `2026-01-30-06` | [Passkey Endpoint (.well-known) Support](deferred/2026-01-30-passkey-endpoint-wellknown.md) |
 | `20260226-2031` | [Attestation Certificate Chain Validation](deferred/20260226-2031-attestation-certificate-validation.md) |

--- a/.claude/issues/deferred/20260226-2022-oauth2-token-storage.md
+++ b/.claude/issues/deferred/20260226-2022-oauth2-token-storage.md
@@ -16,7 +16,7 @@
 
 ## Closed:
 
-## Status: open
+## Status: deferred
 
 ## Priority: low
 
@@ -96,3 +96,5 @@ Defer until there is concrete demand. The security complexity is high and the fe
 - Reason: High value but high risk; requires careful security design. No concrete demand yet
 
 ## Resolution
+
+Deferred. This library is an authentication library, not an OAuth2 API client. Token storage is only needed when the backend needs to call provider APIs on behalf of users, which is outside the library's scope. If concrete demand arises, reconsider with session-scoped approach first.

--- a/.claude/issues/open/20260226-2030-aaguid-credential-deletion-collision.md
+++ b/.claude/issues/open/20260226-2030-aaguid-credential-deletion-collision.md
@@ -65,26 +65,37 @@ None
 
 ## Approach
 
-Possible strategies:
+**Decided: Remove AAGUID-based deletion + add `excludeCredentials` to normal registration flow.**
 
-1. **Skip deletion entirely**: Let the WebAuthn `excludeCredentials` mechanism handle duplicates client-side instead of server-side cleanup. The authenticator itself knows which credentials it holds.
-2. **Add credential_id to the match**: Instead of matching by AAGUID alone, use a more specific identifier. However, the credential_id changes on each registration, so this does not help directly.
-3. **Keep all credentials**: Allow multiple credentials with the same AAGUID per user. The authenticator will present the correct one during authentication.
-4. **User confirmation**: When a matching AAGUID credential exists, ask the user whether to replace it.
+Two changes as a set:
 
-Needs further investigation into WebAuthn specification recommendations for this scenario.
+1. **Remove AAGUID-based credential deletion** from `register.rs`
+   - AAGUID identifies authenticator *type*, not *instance* -- server-side deletion by AAGUID is fundamentally unsafe
+   - No standard WebAuthn guidance recommends server-side AAGUID-based deletion
+   - Stale credentials in DB are harmless: the authenticator selects the correct credential during authentication
+   - Users can manually delete unwanted credentials from the account management page
+
+2. **Add `excludeCredentials` to normal registration flow** (core library)
+   - Currently only the promotion flow (`promotion.rs`) passes `excludeCredentials`
+   - Normal registration via `handle_start_registration_core()` does not
+   - Without `excludeCredentials`, the same authenticator can create duplicate credentials
+   - Pass all of the user's existing credential IDs -- the authenticator checks only the ones it holds
+   - Cannot filter by AAGUID because the new authenticator's AAGUID is unknown at registration option generation time (it is only revealed in the attestation response after registration completes)
 
 ## Related Files
 
-- `oauth2_passkey/src/passkey/main/register.rs` (lines 363-422)
+- `oauth2_passkey/src/passkey/main/register.rs` (lines 363-422) -- AAGUID-based deletion logic to remove
 - `oauth2_passkey/src/passkey/config.rs` (lines 114-119, `PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL`)
+- `oauth2_passkey/src/coordination/passkey.rs` -- `handle_start_registration_core()`, add `excludeCredentials`
+- `oauth2_passkey_axum/src/passkey/promotion.rs` (lines 276-296) -- existing `excludeCredentials` implementation for reference
 
 ## Implementation Tasks
 
-- [ ] Research WebAuthn spec recommendations for same-AAGUID credential management
-- [ ] Decide on approach (skip deletion, keep all, or other)
-- [ ] Implement chosen approach
-- [ ] Add unit tests for multiple same-type authenticator scenario
+- [ ] Remove AAGUID-based credential deletion logic from `register.rs`
+- [ ] Remove related TODO comment at lines 369-373
+- [ ] Add `excludeCredentials` (all user's credential IDs) to `handle_start_registration_core()`
+- [ ] Verify promotion flow's `excludeCredentials` logic can be deduplicated or remains separate
+- [ ] Add unit tests for multiple same-AAGUID credential coexistence
 - [ ] Update documentation
 
 ## Decision Log
@@ -94,5 +105,26 @@ Needs further investigation into WebAuthn specification recommendations for this
 - Context: Migrating incomplete tasks from ToDo.md to issue tracking system
 - Decision: Create as low-priority open issue (correctness bug, rare scenario)
 - Reason: Silently deletes valid credentials in edge case; worth fixing but not urgent
+
+### 2026-03-03: Approach decided -- remove AAGUID deletion + add excludeCredentials
+
+Investigation findings:
+
+1. **AAGUID-based deletion is non-standard**: No WebAuthn spec guidance or major implementation (Google, web.dev) recommends server-side credential deletion by AAGUID. The standard approach is to use `excludeCredentials` for duplicate prevention and let users manage credentials manually.
+
+2. **Stale credentials are harmless**: When a user re-registers on the same authenticator, the old credential remains in the DB but the authenticator responds with the new one during authentication. The old entry is inert.
+
+3. **`excludeCredentials` cannot be AAGUID-filtered**: At the time the server generates registration options, the new authenticator's AAGUID is unknown (revealed only in the attestation response after registration). So `excludeCredentials` must include all of the user's credential IDs. This is correct -- each authenticator only checks credentials it holds and ignores the rest.
+
+4. **Normal registration flow lacks `excludeCredentials`**: Only the promotion flow (`promotion.rs`) currently passes it. The core registration flow must also include it to prevent duplicate credentials on the same authenticator.
+
+Rejected alternatives:
+
+- **Login-credential-aware deletion**: Only delete the credential used for the current Passkey login when re-registering with the same AAGUID. Better than deleting all same-AAGUID credentials (limits damage to one), but still fails when the device's default Password Manager differs from the one used for login (e.g., logged in via Google PM Account A, but new credential goes to Account B). Also does not apply to OAuth2 login -> Passkey registration flow (no login credential to reference).
+
+- **Tracking Password Manager via OAuth2 account association**: Store the OAuth2 Google ID alongside passkey credentials to infer which Google account's Password Manager holds each credential. Fundamentally unreliable -- the OAuth2 login account and the device's active Password Manager are independent (user may log in with Google Account A but the device's default PM is Account B, or iCloud Keychain, or 1Password).
+
+- Decision: Remove AAGUID-based deletion and add `excludeCredentials` to normal registration as a set
+- Reason: Aligns with WebAuthn standard practices, eliminates the correctness bug. Server cannot reliably identify authenticator instances (only types via AAGUID), so any server-side deletion heuristic will have false positives.
 
 ## Resolution

--- a/.claude/issues/wontfix/20260226-2023-auth-method-tracking-in-session.md
+++ b/.claude/issues/wontfix/20260226-2023-auth-method-tracking-in-session.md
@@ -14,9 +14,9 @@
 
 ## Created: 2026-02-26
 
-## Closed:
+## Closed: 2026-03-03
 
-## Status: open
+## Status: wontfix
 
 ## Priority: low
 
@@ -88,4 +88,21 @@ None
 - Decision: Create as low-priority, small-difficulty issue
 - Reason: Low risk, straightforward implementation, but no immediate demand
 
+### 2026-03-03: Closed as wontfix (YAGNI)
+
+Reviewed all proposed use cases and found none are actionable:
+
+1. **Step-up authentication**: Not applicable. Both OAuth2 and Passkey rely on password managers as trust anchors, so there is no meaningful difference in authentication strength. Requiring one method after the other adds friction without improving security.
+
+2. **Conditional UI/UX based on auth method**: No concrete scenario identified where the UI should differ based on how the user logged in. Account management pages are the same regardless.
+
+3. **Security audit trails**: Already covered by login history (`LoginHistoryEntry` records `AuthMethod` for every login). Adding it to the session would be redundant.
+
+4. **Passkey promotion**: The current implementation works without session-level auth method tracking. The OAuth2 popup flow context itself implicitly identifies OAuth2 logins, and the `promotion_check` endpoint uses UA + AAGUID heuristics to decide whether to prompt. No need for `auth_method` in `StoredSession`.
+
+- Decision: Wontfix -- no real use case justifies the added complexity
+- Principle: YAGNI (You Aren't Gonna Need It)
+
 ## Resolution
+
+Closed as wontfix. All proposed use cases were reviewed and none require `auth_method` in the session. Step-up authentication is not meaningful when both auth methods share the same trust anchor (password managers). Audit logging is already handled by login history. Passkey promotion works via OAuth2 popup flow context without session-level tracking.

--- a/.claude/issues/wontfix/20260226-2026-ui-improvements.md
+++ b/.claude/issues/wontfix/20260226-2026-ui-improvements.md
@@ -14,9 +14,9 @@
 
 ## Created: 2026-02-26
 
-## Closed:
+## Closed: 2026-03-03
 
-## Status: open
+## Status: wontfix
 
 ## Priority: low
 
@@ -92,3 +92,5 @@ Incremental improvements prioritized by impact. Start with accessibility and ale
 - Reason: The built-in UI is functional and themed. These are polish improvements that can be done incrementally. Individual sub-tasks can be split into separate issues if needed
 
 ## Resolution
+
+Closed as wontfix. The built-in UI uses browser-native `alert()` and `confirm()` dialogs which are functional across all browsers. Since this is a library, production users will build their own frontend -- investing large effort into polishing the built-in reference UI is not justified. The existing 9-theme CSS system and custom CSS support are sufficient.


### PR DESCRIPTION
- UI Improvements (20260226-2026): wontfix -- built-in UI is functional, library users build their own frontend
- Auth Method Tracking (20260226-2023): wontfix (YAGNI) -- no real use case; step-up auth not meaningful when both methods share same trust anchor
- OAuth2 Token Storage (20260226-2022): deferred -- outside library scope as an auth library, not an API client
- AAGUID Credential Deletion Collision (20260226-2030): decided approach to remove AAGUID-based deletion + add excludeCredentials to normal registration flow, with rejected alternatives documented