### PR TITLE
fix: replace AAGUID-based credential deletion with excludeCredentials

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -80,10 +80,11 @@ This directory contains issue/task tracking files for the project.
 | `20260212-0235` | [Standalone Demo Repository](wontfix/20260212-0235-standalone-demo-repository.md) |
 | `20260213-1500` | [Remove seq=1 from has_admin_privileges()](wontfix/20260213-remove-seq1-from-has-admin-privileges.md) |
 
-### Deferred (4)
+### Deferred (5)
 
 | ID | Title |
 |----|-------|
+| `20260303-0605` | [Adopt WebAuthn Level 3 JSON Serialization API](deferred/20260303-0605-webauthn-json-serialization-api.md) |
 | `20260226-2022` | [OAuth2 Token Storage](deferred/20260226-2022-oauth2-token-storage.md) |
 | `2026-01-23-01` | [Bearer Token Authentication Support](deferred/2026-01-23-bearer-token-support.md) |
 | `2026-01-30-06` | [Passkey Endpoint (.well-known) Support](deferred/2026-01-30-passkey-endpoint-wellknown.md) |

--- a/oauth2_passkey/src/passkey/main/register.rs
+++ b/oauth2_passkey/src/passkey/main/register.rs
@@ -8,8 +8,8 @@ use super::aaguid::{AuthenticatorInfo, get_authenticator_info};
 use super::attestation::{extract_aaguid, verify_attestation};
 use super::challenge::{get_and_validate_options, remove_options};
 use super::types::{
-    AttestationObject, AuthenticatorSelection, PubKeyCredParam, RegisterCredential,
-    RegistrationOptions, RelyingParty, WebAuthnClientData,
+    AttestationObject, AuthenticatorSelection, ExcludeCredentialDescriptor, PubKeyCredParam,
+    RegisterCredential, RegistrationOptions, RelyingParty, WebAuthnClientData,
 };
 use crate::storage::{
     CacheErrorConversion, CacheKey, CachePrefix, get_data, remove_data, store_cache_keyed,
@@ -117,12 +117,13 @@ pub(crate) async fn start_registration(
     // Get or create a user handle
     let user_handle = get_or_create_user_handle(&session_user).await?;
 
-    if let Some(u) = session_user {
+    // Build excludeCredentials for AddToUser mode (logged-in user with existing credentials)
+    let exclude_credentials = if let Some(ref u) = session_user {
         tracing::debug!("User: {:#?}", u);
         let cache_prefix = CachePrefix::session_info();
         let cache_key =
             CacheKey::new(user_handle.clone()).map_err(PasskeyError::convert_storage_error)?;
-        let session_info = SessionInfo { user: u };
+        let session_info = SessionInfo { user: u.clone() };
         store_cache_keyed::<_, PasskeyError>(
             cache_prefix,
             cache_key,
@@ -130,7 +131,26 @@ pub(crate) async fn start_registration(
             (*PASSKEY_CHALLENGE_TIMEOUT).into(),
         )
         .await?;
-    }
+
+        // Look up existing credentials for this user to populate excludeCredentials
+        let user_id = UserId::new(u.id.clone())
+            .map_err(|e| PasskeyError::Validation(format!("Invalid user ID: {e}")))?;
+        match PasskeyStore::get_credentials_by(CredentialSearchField::UserId(user_id)).await {
+            Ok(creds) => creds
+                .into_iter()
+                .map(|c| ExcludeCredentialDescriptor {
+                    type_: "public-key".to_string(),
+                    id: c.credential_id,
+                })
+                .collect(),
+            Err(e) => {
+                tracing::warn!("Failed to fetch credentials for excludeCredentials: {e}");
+                vec![]
+            }
+        }
+    } else {
+        vec![]
+    };
 
     let user_info = PublicKeyCredentialUserEntity {
         user_handle,
@@ -138,13 +158,14 @@ pub(crate) async fn start_registration(
         display_name: displayname.clone(),
     };
 
-    let options = create_registration_options(user_info).await?;
+    let options = create_registration_options(user_info, exclude_credentials).await?;
 
     Ok(options)
 }
 
 async fn create_registration_options(
     user_info: PublicKeyCredentialUserEntity,
+    exclude_credentials: Vec<ExcludeCredentialDescriptor>,
 ) -> Result<RegistrationOptions, PasskeyError> {
     let challenge_str = gen_random_string(32)?;
     let stored_challenge = StoredOptions {
@@ -196,6 +217,7 @@ async fn create_registration_options(
         authenticator_selection,
         timeout: (*PASSKEY_TIMEOUT) * 1000, // Convert seconds to milliseconds
         attestation: PASSKEY_ATTESTATION.to_string(),
+        exclude_credentials,
     };
 
     tracing::debug!("Registration options: {:?}", options);
@@ -353,73 +375,12 @@ pub(crate) async fn prepare_registration_storage(
 
     let ValidatedRegistrationData {
         public_key,
-        user_handle,
         stored_user,
         credential_id,
         aaguid,
         rp_id,
+        ..
     } = validated_data;
-
-    // Handle existing credential cleanup if configured
-    if !*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL {
-        // If PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL is true,
-        // there isn't any pre-existing credentials with this user handle to begin with.
-        // Therefore, we can skip the deletion step.
-
-        // Important todo: we delete credentials for a combination of "AAGUID" and user_handle
-        // But we can't distinguish multiple authenticators of the same type,
-        // e.g. Google Password Managers for different accounts or two Yubikeys with the same model.
-        //
-        // Current implementation will overwrite existing credentials for the same AAGUID regardless of difference in actual authenticator.
-
-        let credentials_with_matching_handle =
-            match PasskeyStore::get_credentials_by(CredentialSearchField::UserHandle(
-                crate::passkey::UserHandle::new(user_handle.to_string()),
-            ))
-            .await
-            {
-                Ok(creds) => creds,
-                Err(e) => {
-                    tracing::warn!(
-                        "Error getting credentials for user handle {}: {}",
-                        user_handle,
-                        e
-                    );
-                    // Continue with registration - don't fail just because we couldn't get existing credentials
-                    vec![]
-                }
-            };
-
-        // Filter and delete credentials that match user_handle, user_id, and aaguid
-        for cred in credentials_with_matching_handle {
-            if cred.aaguid == aaguid && cred.user_id == user_id.as_str() {
-                let credential_id = crate::passkey::CredentialId::new(cred.credential_id.clone())
-                    .map_err(|e| {
-                    PasskeyError::Validation(format!("Invalid credential ID: {e}"))
-                })?;
-                match PasskeyStore::delete_credential_by(CredentialSearchField::CredentialId(
-                    credential_id,
-                ))
-                .await
-                {
-                    Ok(_) => {
-                        tracing::info!(
-                            "Removed existing credential with matching user_handle, user_id, and aaguid: {}",
-                            cred.credential_id
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Error removing existing credential {}: {}",
-                            cred.credential_id,
-                            e
-                        );
-                        // Continue with registration - don't fail just because we couldn't remove existing credentials
-                    }
-                }
-            }
-        }
-    }
 
     // Create the credential object ready for storage
     let credential = PasskeyCredential {

--- a/oauth2_passkey/src/passkey/main/register/tests.rs
+++ b/oauth2_passkey/src/passkey/main/register/tests.rs
@@ -630,7 +630,7 @@ async fn test_create_registration_options_integration() {
     };
 
     // Call the function under test
-    let options = super::create_registration_options(user_info.clone()).await;
+    let options = super::create_registration_options(user_info.clone(), vec![]).await;
     assert!(options.is_ok(), "Failed to create registration options");
 
     let registration_options = options.unwrap();

--- a/oauth2_passkey/src/passkey/main/types.rs
+++ b/oauth2_passkey/src/passkey/main/types.rs
@@ -116,6 +116,19 @@ pub struct RegistrationOptions {
     pub(super) authenticator_selection: AuthenticatorSelection,
     pub(super) timeout: u32,
     pub(super) attestation: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) exclude_credentials: Vec<ExcludeCredentialDescriptor>,
+}
+
+/// Descriptor for a credential to exclude during registration.
+///
+/// Used in `excludeCredentials` to prevent duplicate credential creation
+/// on the same authenticator.
+#[derive(Serialize, Debug)]
+pub(super) struct ExcludeCredentialDescriptor {
+    #[serde(rename = "type")]
+    pub(super) type_: String,
+    pub(super) id: String,
 }
 
 #[derive(Serialize, Debug)]

--- a/oauth2_passkey/src/passkey/mod.rs
+++ b/oauth2_passkey/src/passkey/mod.rs
@@ -40,7 +40,9 @@ pub(crate) use main::{
 };
 
 pub(crate) use storage::PasskeyStore;
-pub(crate) use types::{CredentialSearchField, UserHandle, UserName};
+#[cfg(test)]
+pub(crate) use types::UserHandle;
+pub(crate) use types::{CredentialSearchField, UserName};
 
 pub(crate) async fn init() -> Result<(), PasskeyError> {
     // Validate required environment variables early

--- a/oauth2_passkey/src/passkey/types.rs
+++ b/oauth2_passkey/src/passkey/types.rs
@@ -195,6 +195,7 @@ impl UserHandle {
     ///
     /// # Returns
     /// * A new UserHandle instance
+    #[cfg(test)]
     pub fn new(handle: String) -> Self {
         Self(handle)
     }

--- a/oauth2_passkey_axum/src/passkey/promotion.rs
+++ b/oauth2_passkey_axum/src/passkey/promotion.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides a promotion flow that encourages users to register a passkey
 //! after successful OAuth2 login. It wraps the existing registration core function
-//! and adds `excludeCredentials` to prevent duplicate registrations on the same authenticator.
+//! which includes `excludeCredentials` to prevent duplicate registrations on the same authenticator.
 //!
 //! The promotion flow uses the OAuth2 popup window itself:
 //! after OAuth2 callback, instead of redirecting to `popup_close.j2`,
@@ -25,8 +25,8 @@ use serde_json::json;
 use std::collections::HashMap;
 
 use oauth2_passkey::{
-    O2P_ROUTE_PREFIX, RegistrationMode, RegistrationStartRequest, SessionUser, UserId,
-    get_authenticator_info_batch, handle_start_registration_core, list_credentials_core,
+    O2P_ROUTE_PREFIX, RegistrationMode, RegistrationOptions, RegistrationStartRequest, SessionUser,
+    UserId, get_authenticator_info_batch, handle_start_registration_core, list_credentials_core,
 };
 
 use super::super::config::O2P_CUSTOM_CSS_URL;
@@ -241,15 +241,16 @@ fn is_credential_likely_available(authenticator_name: &str, ua: &str) -> bool {
 
 /// Start passkey registration for promotion flow
 ///
-/// This handler wraps `handle_start_registration_core()` and appends `excludeCredentials`
-/// from the user's existing credentials. The authenticator will reject with `InvalidStateError`
-/// if it already has a matching credential, eliminating the need for server-side per-device detection.
+/// The core registration function (`handle_start_registration_core`) already includes
+/// `excludeCredentials` in the response for AddToUser mode. The authenticator will reject
+/// with `InvalidStateError` if it already has a matching credential, eliminating the need
+/// for server-side per-device detection.
 ///
 /// Requires authentication (AddToUser mode only).
 async fn promotion_start_registration(
     auth_user: AuthUser,
     Json(request): Json<RegistrationStartRequest>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+) -> Result<Json<RegistrationOptions>, (StatusCode, String)> {
     // Only allow AddToUser mode for promotion
     if request.mode != RegistrationMode::AddToUser {
         return Err((
@@ -260,42 +261,11 @@ async fn promotion_start_registration(
 
     let session_user = SessionUser::from(&auth_user);
 
-    // Call existing core function unchanged
     let registration_options = handle_start_registration_core(Some(&session_user), request)
         .await
         .into_response_error()?;
 
-    // Serialize to JSON
-    let mut options_json = serde_json::to_value(&registration_options).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to serialize registration options: {e}"),
-        )
-    })?;
-
-    // Append excludeCredentials from user's existing credentials
-    let user_id = UserId::new(auth_user.id.clone()).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Invalid user ID: {e}"),
-        )
-    })?;
-
-    let credentials = list_credentials_core(user_id).await.into_response_error()?;
-
-    let exclude_credentials: Vec<serde_json::Value> = credentials
-        .iter()
-        .map(|c| {
-            json!({
-                "type_": "public-key",
-                "id": c.credential_id
-            })
-        })
-        .collect();
-
-    options_json["excludeCredentials"] = json!(exclude_credentials);
-
-    Ok(Json(options_json))
+    Ok(Json(registration_options))
 }
 
 #[cfg(test)]

--- a/oauth2_passkey_axum/static/passkey.js
+++ b/oauth2_passkey_axum/static/passkey.js
@@ -354,6 +354,16 @@ async function startRegistration(mode, username = null, displayname = null) {
         options.challenge = base64URLToUint8Array(options.challenge);
         options.user.id = base64URLToUint8Array(userHandle);
 
+        // Transform excludeCredentials
+        if (options.excludeCredentials && Array.isArray(options.excludeCredentials)) {
+            options.excludeCredentials = options.excludeCredentials.map(credential => ({
+                type: 'public-key',
+                id: base64URLToUint8Array(credential.id),
+            }));
+        } else {
+            options.excludeCredentials = [];
+        }
+
         console.log('Registration options:', options);
         console.log('Registration user handle:', userHandle);
 


### PR DESCRIPTION
Remove unsafe AAGUID-based deletion that could delete wrong credentials when a user has multiple authenticators of the same type (e.g., two Google accounts). Instead, populate excludeCredentials in the registration options so the authenticator itself prevents duplicate registrations.

- Add ExcludeCredentialDescriptor struct and exclude_credentials field
- Populate excludeCredentials from user's existing credentials (AddToUser)
- Remove AAGUID-based deletion block from prepare_registration_storage()
- Add excludeCredentials base64url->Uint8Array transform in passkey.js
- Simplify promotion handler to use core's excludeCredentials directly
- Mark UserHandle::new and re-export as #[cfg(test)] (only test usage)