### PR TITLE
docs: reprioritize open issues to focus on next 4 targets

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -10,15 +10,15 @@ This directory contains issue/task tracking files for the project.
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
+| `20260226-2020` | high | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
 | `20260226-2018` | high | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
-| `20260226-2019` | high | large | [Finalize Public API for 1.0 Release](open/20260226-2019-finalize-public-api.md) |
+| `20260226-2025` | high | large | [E2E Tests](open/20260226-2025-e2e-tests.md) |
+| `20260226-1814` | high | large | [Device Bound Session Credentials (DBSC) Support](open/20260226-1814-device-bound-session-credentials.md) |
+| `20260226-2019` | medium | large | [Finalize Public API for 1.0 Release](open/20260226-2019-finalize-public-api.md) |
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
-| `20260226-2020` | medium | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
-| `20260226-1814` | low | large | [Device Bound Session Credentials (DBSC) Support](open/20260226-1814-device-bound-session-credentials.md) |
-| `20260226-2025` | low | large | [E2E Tests](open/20260226-2025-e2e-tests.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 | `20260331-1517` | low | small | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](open/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |
 

--- a/.claude/issues/open/20260226-1814-device-bound-session-credentials.md
+++ b/.claude/issues/open/20260226-1814-device-bound-session-credentials.md
@@ -18,7 +18,7 @@
 
 ## Status: open
 
-## Priority: low
+## Priority: high
 
 ## Difficulty: large
 

--- a/.claude/issues/open/20260226-2019-finalize-public-api.md
+++ b/.claude/issues/open/20260226-2019-finalize-public-api.md
@@ -18,7 +18,7 @@
 
 ## Status: open
 
-## Priority: high
+## Priority: medium
 
 ## Difficulty: large
 

--- a/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
+++ b/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
@@ -18,7 +18,7 @@
 
 ## Status: open
 
-## Priority: medium
+## Priority: high
 
 ## Difficulty: large
 

--- a/.claude/issues/open/20260226-2025-e2e-tests.md
+++ b/.claude/issues/open/20260226-2025-e2e-tests.md
@@ -18,7 +18,7 @@
 
 ## Status: open
 
-## Priority: low
+## Priority: high
 
 ## Difficulty: large
 


### PR DESCRIPTION
Promote to high: expand-oauth2-providers (20260226-2020), e2e-tests (20260226-2025), device-bound-session-credentials (20260226-1814). Demote finalize-public-api (20260226-2019) from high to medium. Reorder README backlog table to reflect intended tackle order.