### PR TITLE
fix: update rustls-webpki and fix pre-existing clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "demo-both"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "demo-cross-origin"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "demo-custom-login"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "demo-live"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "demo-oauth2"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "demo-passkey"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "demo-profile"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "demo-todo"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "oauth2-passkey"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "oauth2-passkey-axum"
-version = "0.4.1-dev"
+version = "0.5.1-dev"
 dependencies = [
  "askama",
  "axum",
@@ -2452,9 +2452,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/oauth2_passkey/src/config/tests.rs
+++ b/oauth2_passkey/src/config/tests.rs
@@ -70,7 +70,7 @@ fn test_demo_mode_rejects_invalid() {
 #[test]
 fn test_demo_mode_accepts_true() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*O2P_DEMO_MODE, true);
+        assert!(*O2P_DEMO_MODE);
         return;
     }
     let output = run_child(
@@ -84,7 +84,7 @@ fn test_demo_mode_accepts_true() {
 #[test]
 fn test_demo_mode_accepts_false() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*O2P_DEMO_MODE, false);
+        assert!(!(*O2P_DEMO_MODE));
         return;
     }
     let output = run_child(
@@ -131,7 +131,7 @@ fn test_signal_api_mode_accepts_valid() {
 #[test]
 fn test_demo_mode_defaults_to_false() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*O2P_DEMO_MODE, false);
+        assert!(!(*O2P_DEMO_MODE));
         return;
     }
     let output = run_child_without_env(

--- a/oauth2_passkey/src/passkey/config/tests.rs
+++ b/oauth2_passkey/src/passkey/config/tests.rs
@@ -182,7 +182,7 @@ fn test_passkey_require_resident_key_rejects_invalid() {
 #[test]
 fn test_passkey_require_resident_key_accepts_valid() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*PASSKEY_REQUIRE_RESIDENT_KEY, false);
+        assert!(!(*PASSKEY_REQUIRE_RESIDENT_KEY));
         return;
     }
     let output = run_child(
@@ -246,7 +246,7 @@ fn test_passkey_user_handle_unique_rejects_invalid() {
 #[test]
 fn test_passkey_user_handle_unique_accepts_valid() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL, true);
+        assert!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL);
         return;
     }
     let output = run_child(
@@ -260,7 +260,7 @@ fn test_passkey_user_handle_unique_accepts_valid() {
 #[test]
 fn test_passkey_user_handle_unique_accepts_uppercase() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL, true);
+        assert!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL);
         return;
     }
     let output = run_child(
@@ -341,7 +341,7 @@ fn test_passkey_resident_key_defaults_to_required() {
 #[test]
 fn test_passkey_require_resident_key_defaults_to_true() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*PASSKEY_REQUIRE_RESIDENT_KEY, true);
+        assert!(*PASSKEY_REQUIRE_RESIDENT_KEY);
         return;
     }
     let output = run_child_without_env(
@@ -367,7 +367,7 @@ fn test_passkey_user_verification_defaults_to_discouraged() {
 #[test]
 fn test_passkey_user_handle_unique_defaults_to_false() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL, false);
+        assert!(!(*PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL));
         return;
     }
     let output = run_child_without_env(

--- a/oauth2_passkey_axum/src/config/tests.rs
+++ b/oauth2_passkey_axum/src/config/tests.rs
@@ -22,7 +22,7 @@ fn test_respond_with_x_csrf_token_rejects_invalid() {
 #[test]
 fn test_respond_with_x_csrf_token_accepts_valid() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*O2P_RESPOND_WITH_X_CSRF_TOKEN, false);
+        assert!(!(*O2P_RESPOND_WITH_X_CSRF_TOKEN));
         return;
     }
     let output = run_child(
@@ -102,7 +102,7 @@ fn test_passkey_promotion_accepts_ask() {
 #[test]
 fn test_respond_with_x_csrf_token_defaults_to_true() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*O2P_RESPOND_WITH_X_CSRF_TOKEN, true);
+        assert!(*O2P_RESPOND_WITH_X_CSRF_TOKEN);
         return;
     }
     let output = run_child_without_env(

--- a/oauth2_passkey_axum/src/cors/tests.rs
+++ b/oauth2_passkey_axum/src/cors/tests.rs
@@ -22,7 +22,7 @@ fn test_cors_allow_credentials_rejects_invalid() {
 #[test]
 fn test_cors_allow_credentials_accepts_valid() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*CORS_ALLOW_CREDENTIALS, true);
+        assert!(*CORS_ALLOW_CREDENTIALS);
         return;
     }
     let output = run_child(
@@ -36,7 +36,7 @@ fn test_cors_allow_credentials_accepts_valid() {
 #[test]
 fn test_cors_allow_credentials_defaults_to_false() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
-        assert_eq!(*CORS_ALLOW_CREDENTIALS, false);
+        assert!(!(*CORS_ALLOW_CREDENTIALS));
         return;
     }
     let output = run_child_without_env(


### PR DESCRIPTION
  - Update rustls-webpki 0.103.10 -> 0.103.12 to fix RUSTSEC-2026-0098 (name constraints for URI names incorrectly accepted)
  - Sync Cargo.lock demo crate versions with workspace (0.4.1-dev -> 0.5.1-dev)
  - Fix pre-existing clippy warnings in test files: replace assert_eq!(x, true/false)

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>