### PR TITLE
  refactor: introduce ProviderConfig abstraction and OIDC naming cleanup

### DIFF
--- a/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
+++ b/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
@@ -231,7 +231,7 @@ Tests and verification:
 - [x] `cargo test --manifest-path oauth2_passkey/Cargo.toml` passes
 - [x] `cargo test --manifest-path oauth2_passkey_axum/Cargo.toml --all-features` passes
 - [x] `cargo clippy --all-targets --all-features` clean
-- [ ] Manual Google login end-to-end test via demo-oauth2
+- [x] Manual Google login end-to-end test via demo-oauth2
 
 ### Step 2: Add Auth0 as a second instance (target 2026-04-19)
 

--- a/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
+++ b/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
@@ -43,26 +43,238 @@ None
 
 ## Approach
 
-1. Implement providers one at a time, starting with the most requested
-2. Leverage existing OIDC Discovery infrastructure where possible
-3. Handle provider-specific quirks in dedicated modules
-4. Each provider should be independently enableable via environment variables
+Revised on 2026-04-15 (second revision, same day) after reconsidering the
+order. The original phased plan put "Auth0 switch mode" as Phase 0 and "multi-
+instance refactor" as Phase 1. That ordering was chosen for deadline safety
+(an Auth0 LT on 2026-04-20), but it wastes work: Phase 0 would add narrowly-
+scoped fixes that Phase 1 then rewrites. The revised ordering does the
+architectural work first and adds Auth0 as a trivial follow-up:
+
+- **Step 1 — Multi-IdP capable internals, Google-only at runtime** (target:
+  2026-04-18). Replace the global `LazyLock` config with a provider registry.
+  Thread a `&ProviderConfig` context through every OAuth2 flow function. Add
+  a `provider` field to `StateParams` for callback dispatch. Per-instance
+  CSRF cookie names. Per-instance OIDC Discovery cache. Make `IdInfo` /
+  `GoogleUserInfo` fields that are Google-specific optional. Fix the OIDC
+  Discovery trailing-slash issuer comparison bug. Done condition: all existing
+  tests pass unchanged, the Google login flow works identically from a
+  user's perspective, but the codebase is ready to add a second instance
+  without any further refactoring.
+- **Step 2 — Add Auth0 as a second instance** (target: 2026-04-19). Pure
+  configuration work if Step 1 is truly done: create an Auth0 tenant, register
+  the app, add `OAUTH2_INSTANCES=google,auth0` and `OAUTH2_AUTH0_*` entries
+  to the demo `.env`, verify end-to-end. No code changes expected — if code
+  changes are needed, Step 1 was incomplete.
+- **Phase 2 — GitHub (non-OIDC) flow**. Separate flow branch (no id_token,
+  userinfo via REST, no nonce/at_hash). Introduces an `OAuth2Flow` trait.
+- **Phase 3 — Apple Sign-In**. `response_mode=form_post` forced, `client_secret`
+  as ES256 JWT, name/email only in the initial authorization form body.
+- **Phase 4 — FedCM multi-provider** (optional, only if demand appears).
+
+Step 1 and Step 2 together replace what the earlier revision called Phase 0
+and Phase 1. Steps 1-2 are the deadline-critical path; Phases 2-4 are deferred
+until after the LT.
+
+### Fallback plan
+
+If by Saturday morning (2026-04-18) Step 1 is not on track to finish the
+weekend, fall back to the earlier "Phase 0 minimal" plan on a separate branch:
+fix discovery trailing-slash, make `IdInfo` fields optional, add
+`OAUTH2_PROVIDER_NAME` env var. That is ~80 lines and gets Auth0 working via
+switch mode for the LT. Step 1 then resumes after the LT as an unhurried
+refactor. This fallback branch should be prepared preemptively on Wednesday
+so it is available if needed.
+
+### Design decisions fixed on 2026-04-15 (for Step 1)
+
+To avoid losing time to design churn mid-refactor, the following are locked:
+
+- **Configuration format**: one `LazyLock<ProviderConfig>` static per
+  supported provider, listed explicitly in code. No `OAUTH2_INSTANCES` env var
+  and no HashMap registry — the set of providers is fixed at compile time by
+  the `ProviderKind` enum variants. Google is unconditional (panics if
+  `OAUTH2_GOOGLE_CLIENT_ID` / `OAUTH2_GOOGLE_CLIENT_SECRET` are missing,
+  matching current behaviour). Optional providers (e.g. Auth0 in Step 2) use
+  `LazyLock<Option<ProviderConfig>>` and are enabled by setting their env vars.
+  Each provider's `redirect_uri` is built as
+  `{ORIGIN}{O2P_PREFIX}/oauth2/{provider}/authorized` during static init.
+  TOML/JSON config files are explicitly deferred; revisit if instance count
+  grows past ~3 in practice.
+- **Callback routing**: per-instance `/oauth2/{provider}/authorized`. The
+  provider is identified from the URL path at the Axum router level, before
+  any state decoding. `StateParams` still carries `provider` as a
+  defense-in-depth cross-check. This is a **breaking change** from the
+  previous single `/oauth2/authorized` callback, requiring existing users
+  to update their IdP console redirect URIs from `/oauth2/authorized` to
+  `/oauth2/google/authorized`. The old URL is **not** kept as an alias:
+  instead, a temporary `410 Gone` handler at `/oauth2/authorized` returns
+  a JSON payload pointing to the new URL, retained for 2-3 releases so
+  mis-configured setups fail loudly with a clear message. Rationale: at
+  0.x versioning, minor-bump breaking changes are allowed; the migration
+  cost for existing users is a single redirect URI edit in the IdP
+  console; maintaining a dual code path with the old "provider from state
+  only" approach would perpetuate the weaker defense-in-depth property
+  that was the main reason to move callback identification into the URL
+  in the first place.
+- **Reserved provider names**: `ProviderRegistry::init_from_env` rejects
+  any instance name that would collide with existing literal routes under
+  `/oauth2/*`: `authorized`, `accounts`, `fedcm`, `popup_close`, `oauth2.js`.
+  Also reject names containing `/`, `.`, or characters outside `[a-z0-9_-]`.
+- **Next release**: `0.6.0` (minor bump). The callback URL change is a
+  SemVer breaking change and must not ship as a patch. CHANGELOG gets a
+  prominent "Breaking Changes" section with a 2-line migration guide.
+- **CSRF cookie name**: `__Host-CsrfId` remains a single global name, not
+  per-instance. The single-cookie design is the mechanism that implements
+  the existing "latest flow wins" policy: when a new OAuth2 flow starts
+  while another is in flight, the new flow's cookie overwrites the old
+  one, causing the abandoned flow's callback to fail at `csrf_checks`
+  (cookie token will not match the cached token keyed by `state.csrf_id`).
+  This is intentional and must be preserved under multi-IdP: OAuth2
+  callbacks have irreversible side effects (session rotation, account
+  linking, login history insertion), and silently completing an abandoned
+  flow in parallel with a newer one would create ghost state the user
+  did not consent to. Fail-closed is the safer direction. `ProviderConfig`
+  must **not** carry a `csrf_cookie_name` field; `OAUTH2_CSRF_COOKIE_NAME`
+  stays as a global `LazyLock`. Step 1 adds a policy comment near
+  `csrf_checks` so future "clean-up" PRs that try to make the cookie
+  per-instance understand the intent.
+- **Claim → OAuth2Account conversion**: replace the `From<GoogleIdInfo>` /
+  `From<GoogleUserInfo>` trait impls with free functions that take a
+  `provider_name: &str` argument. The provider name is supplied by the
+  callback handler from the URL path (with `StateParams` cross-check), so
+  DB rows get the correct instance name instead of hardcoded `"google"`.
 
 ## Related Files
 
-- `oauth2_passkey/src/oauth2/` - OAuth2 implementation
-- `oauth2_passkey/src/coordination/oauth2.rs` - OAuth2 coordination
-- `oauth2_passkey_axum/src/oauth2.rs` - OAuth2 handlers
+- `oauth2_passkey/src/oauth2/config.rs` - Global `LazyLock` config (Phase 1 replaces this with a registry)
+- `oauth2_passkey/src/oauth2/discovery.rs` - OIDC Discovery; has trailing-slash issuer comparison bug blocking Auth0
+- `oauth2_passkey/src/oauth2/main/core.rs` - OAuth2 flow core; `OAUTH2_GOOGLE_CLIENT_ID` hardcoded in auth URL
+- `oauth2_passkey/src/oauth2/main/google.rs` - Token exchange + userinfo fetch (Google-named but mostly generic OIDC)
+- `oauth2_passkey/src/oauth2/main/idtoken.rs` - `IdInfo` struct with Google-specific required fields
+- `oauth2_passkey/src/oauth2/main/fedcm.rs` - FedCM support (Google-only, unchanged in Phase 0)
+- `oauth2_passkey/src/oauth2/types.rs` - `From<GoogleUserInfo/IdInfo> for OAuth2Account` with hardcoded `provider: "google"`
+- `oauth2_passkey/src/coordination/oauth2.rs` - Coordination layer; tracing span hardcodes `provider = "google"`
+- `oauth2_passkey_axum/src/oauth2.rs` - Axum handlers; `/oauth2/google` route
+- `oauth2_passkey_axum/static/oauth2.js` - Frontend; hardcodes `/oauth2/google` and Google FedCM configURL
+- `dot.env.example` - Environment variable documentation
 
 ## Implementation Tasks
 
-- [ ] Design provider abstraction layer (if not already sufficient)
-- [ ] Implement GitHub OAuth2 provider
-- [ ] Implement Apple Sign-In provider
-- [ ] Implement Microsoft/Azure AD provider
-- [ ] Add provider-specific configuration documentation
-- [ ] Add integration tests for each provider
-- [ ] Update demo applications
+### Step 1: Multi-IdP capable internals, Google-only at runtime (target 2026-04-18)
+
+Provider infrastructure (simplified — no registry, no HashMap, no `OAUTH2_INSTANCES`):
+
+- [ ] Create `oauth2_passkey/src/oauth2/provider.rs` with `ProviderKind` enum (`pub(crate)`), `ProviderConfig` struct (`pub(crate)`), `GOOGLE_PROVIDER: LazyLock<ProviderConfig>` static, and `provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig>` match dispatcher
+- [ ] `ProviderConfig` owns its OIDC Discovery cache as `OnceCell<OidcDiscoveryDocument>` (replacing the global `OIDC_DISCOVERY_CACHE`)
+- [ ] `ProviderConfig` async methods: `token_url()`, `jwks_url()`, `userinfo_url()`, `expected_issuer()` (reading from discovery doc via `OnceCell`)
+- [ ] `ProviderKind::from_path_segment(&str) -> Option<ProviderKind>` for URL path parsing; `ProviderKind::as_str() -> &'static str` for display / DB values
+- [ ] Per-provider `redirect_uri` built as `{ORIGIN}{O2P_PREFIX}/oauth2/{provider_name}/authorized` in `ProviderConfig` initialization
+- [ ] `ProviderConfig` does **not** carry `csrf_cookie_name`. `OAUTH2_CSRF_COOKIE_NAME` stays global — see "latest wins" policy in Design decisions
+- [ ] Reserved provider names (`authorized`, `accounts`, `fedcm`, `popup_close`, `oauth2.js`) documented as compile-time constraint comment in `provider.rs` (no runtime rejection needed since providers are code-defined, not env-configured)
+
+Thread `&ProviderConfig` through flow functions:
+
+- [ ] `prepare_oauth2_auth_request(provider, headers, mode)` takes an instance name, looks up the config
+- [ ] `get_idinfo_userinfo(ctx, auth_response)` reads client_id / client_secret / endpoints from ctx
+- [ ] `exchange_code_for_token(ctx, code, verifier)` in `main/google.rs`
+- [ ] `fetch_user_data_from_google(ctx, access_token)` in `main/google.rs` (rename deferred to Phase 2)
+- [ ] `csrf_checks` signature may or may not take `ctx` — cookie name is still global, so `ctx` only needed if other checks become per-instance. Prefer keeping the current signature if nothing else needs ctx there
+- [ ] Add a policy comment near `csrf_checks` / the cookie `Set-Cookie` site explaining why the cookie name is single and global ("latest flow wins" rationale), referencing the 2026-04-16 Decision Log entry
+- [ ] Add a short paragraph to `docs/src/security/oauth2-security.md` under "Note on CSRF Tokens in the System" documenting the "latest flow wins" behaviour explicitly (currently undocumented)
+- [ ] `prepare_fedcm_nonce(ctx)` / `validate_fedcm_token(ctx, token, nonce_id)` — FedCM stays Google-only but accepts ctx for API symmetry
+
+State and callback dispatch:
+
+- [ ] Add `provider: String` field to `StateParams` (as defense-in-depth cross-check, not the primary dispatch signal)
+- [ ] `prepare_oauth2_auth_request` writes the instance name into state
+- [ ] Callback handler receives `Path(provider)` from Axum, looks up `ProviderRegistry` **before** decoding state, then decodes state and asserts `state.provider == path_provider` (reject mismatch as security event)
+- [ ] Existing `OAUTH2_RESPONSE_MODE` global becomes `ctx.response_mode` — callback method validation uses ctx
+
+Claim extraction refactor:
+
+- [ ] Make `IdInfo` fields optional: `azp`, `given_name`, `family_name`, `email_verified`
+- [ ] Make `GoogleUserInfo` fields optional to match
+- [ ] Replace `impl From<GoogleIdInfo> for OAuth2Account` with free function `oauth2_account_from_idinfo(idinfo, provider_name)`
+- [ ] Replace `impl From<GoogleUserInfo> for OAuth2Account` with free function `oauth2_account_from_userinfo(userinfo, provider_name)`
+- [ ] Callers in `coordination/oauth2.rs` pass the URL-derived provider name to the free functions
+
+OIDC Discovery and endpoint resolution:
+
+- [ ] Fix trailing-slash issuer comparison in `fetch_oidc_discovery` (normalize both sides)
+- [ ] Remove global `OIDC_DISCOVERY_CACHE`, `OAUTH2_ISSUER_URL`, `OAUTH2_REDIRECT_URI`, `OAUTH2_GOOGLE_CLIENT_ID/SECRET`, `OAUTH2_RESPONSE_MODE`, `OAUTH2_QUERY_STRING` from `config.rs` — these move into `ProviderConfig`
+- [ ] **Keep** `OAUTH2_CSRF_COOKIE_NAME` and `OAUTH2_CSRF_COOKIE_MAX_AGE` as global `LazyLock` (intentional, see "latest wins" policy)
+
+Axum route and handler:
+
+- [ ] Change initiate route from `/oauth2/google` to `/oauth2/{provider}` with `Path<String>` extraction
+- [ ] `google_auth` → `oauth2_initiate(Path(provider), ...)` — looks up instance, calls `prepare_oauth2_auth_request(&provider, headers, mode)`
+- [ ] Change callback route from `/oauth2/authorized` to `/oauth2/{provider}/authorized` with both `.get()` and `.post()` (provider in URL path, not state)
+- [ ] Add `410 Gone` handler at `/oauth2/authorized` returning JSON `{"error": "callback URL moved", "new_url_pattern": "/oauth2/{provider}/authorized"}` — retained for 2-3 releases as a helpful migration error
+- [ ] `get_google_client_id()` public API: for Step 1, resolve it to the Google instance's client_id via the registry (FedCM still depends on this)
+
+Frontend:
+
+- [ ] Update `static/oauth2.js` initiate URL (already `/oauth2/google` — stays the same)
+- [ ] FedCM path unchanged (Google-only)
+
+Tests and verification:
+
+- [ ] Update `oauth2/main/core/tests.rs` to use a test `ProviderConfig` helper
+- [ ] Update `oauth2/main/google/tests.rs` similarly
+- [ ] Update `oauth2/main/idtoken/tests.rs` for optional fields
+- [ ] Update `oauth2/config/tests.rs` for registry initialization
+- [ ] New test: `GOOGLE_PROVIDER` LazyLock initializes from `OAUTH2_GOOGLE_CLIENT_ID` / `OAUTH2_GOOGLE_CLIENT_SECRET` env vars
+- [ ] New test: `ProviderKind::from_path_segment` parses known and unknown provider names
+- [ ] New test: `provider_for` returns `Some` for Google, returns correct `Option` for optional providers
+- [ ] New test: callback handler reads provider from URL path and cross-checks with `state.provider`
+- [ ] New test: callback handler rejects URL/state provider mismatch as a security event
+- [ ] New test: `410 Gone` handler at `/oauth2/authorized` returns the migration payload
+- [ ] `cargo test --manifest-path oauth2_passkey/Cargo.toml` passes
+- [ ] `cargo test --manifest-path oauth2_passkey_axum/Cargo.toml --all-features` passes
+- [ ] `cargo clippy --all-targets --all-features` clean
+- [ ] Manual Google login end-to-end test via demo-oauth2
+
+### Step 2: Add Auth0 as a second instance (target 2026-04-19)
+
+- [ ] Create Auth0 tenant and register a regular web application
+- [ ] Configure allowed callback URL `{ORIGIN}/o2p/oauth2/auth0/authorized`
+- [ ] Update existing Google Cloud Console redirect URI to `{ORIGIN}/o2p/oauth2/google/authorized` (for demo environment)
+- [ ] Add Auth0 example block to `dot.env.example`
+- [ ] Configure demo-oauth2 `.env` with `OAUTH2_INSTANCES=google,auth0` plus `OAUTH2_AUTH0_*` settings
+- [ ] Run demo, log in via Auth0 button, verify DB row has `provider="auth0"` and correct `sub`
+- [ ] Verify Google login still works concurrently
+- [ ] Capture screenshots for LT
+- [ ] If any code change is needed here, mark Step 1 as incomplete and address
+
+### Fallback: Phase 0 minimal (prepared preemptively on 2026-04-15, used only if Step 1 stalls)
+
+- [ ] Branch off `feature/expand-oauth2-providers` on 2026-04-15 as `feature/auth0-switch-mode`
+- [ ] Fix OIDC Discovery issuer trailing-slash comparison
+- [ ] Make `IdInfo` fields optional
+- [ ] Make `GoogleUserInfo` fields optional
+- [ ] Add `OAUTH2_PROVIDER_NAME` env var (default `"google"`), read in claim-to-account conversion
+- [ ] Add Auth0 example to `dot.env.example` (switch mode)
+- [ ] Activate only if Step 1 is not on track by 2026-04-18 morning
+
+### Phase 2: GitHub (non-OIDC)
+
+- [ ] Introduce `OAuth2Flow` trait with OIDC and non-OIDC implementations
+- [ ] GitHub flow: code exchange + `GET /user` + `GET /user/emails`, no id_token, no nonce
+- [ ] GitHub-specific claim mapping
+- [ ] Integration test with mocked GitHub API
+
+### Phase 3: Apple Sign-In
+
+- [ ] Force `response_mode=form_post` per instance
+- [ ] Generate `client_secret` as ES256 JWT from Apple private key
+- [ ] Extract name/email from initial form body (first authorization only)
+- [ ] Handle Apple private email relay
+- [ ] Integration test
+
+### Phase 4: FedCM multi-provider (optional)
+
+- [ ] Per-instance FedCM configURL
+- [ ] Frontend FedCM `providers: [...]` array support
 
 ## Decision Log
 
@@ -71,5 +283,441 @@ None
 - Context: Migrating incomplete tasks from ToDo.md to issue tracking system
 - Decision: Create as medium-priority, large-difficulty issue
 - Reason: Multiple providers, each with unique requirements; important for adoption but not blocking current users
+
+### 2026-04-15: Codebase investigation + phased plan
+
+#### Current architecture (what's Google-specific)
+
+The OAuth2 module is written as if there is exactly one provider. Concretely:
+
+- `oauth2/config.rs` uses `LazyLock` globals for every setting
+  (`OAUTH2_ISSUER_URL`, `OAUTH2_GOOGLE_CLIENT_ID/SECRET`, `OAUTH2_SCOPE`,
+  `OAUTH2_RESPONSE_MODE`, `OAUTH2_REDIRECT_URI`, ...). All `get_*_url()`
+  helpers return a single global value.
+- `OIDC_DISCOVERY_CACHE: OnceLock<OidcDiscoveryDocument>` — first-write-wins,
+  can only cache one provider's discovery document.
+- `oauth2/main/core.rs:141-151` builds the auth URL with a hardcoded reference
+  to `OAUTH2_GOOGLE_CLIENT_ID`.
+- `oauth2/main/idtoken.rs` defines `IdInfo` with Google-specific required
+  fields (`azp`, `given_name`, `family_name`, `email_verified: bool`, plus
+  optional `hd` and `at_hash`).
+- `oauth2/types.rs:76-120` hardcodes `provider: "google"` and
+  `provider_user_id: format!("google_{}", sub)` in the `From` impls.
+- `oauth2_passkey_axum/src/oauth2.rs` exposes `/oauth2/google` as a fixed route.
+- `static/oauth2.js` hardcodes `/oauth2/google` and the Google FedCM configURL.
+- The DB schema stores `provider` and has `UNIQUE(provider, provider_user_id)`,
+  so the storage layer is already multi-provider-ready — this is the only
+  layer that does not need changes.
+
+#### Why "just point at a different issuer" does not work
+
+A first instinct was that since `OAUTH2_ISSUER_URL` is already an env var,
+switching to e.g. Auth0 should work by just changing it. Investigation found
+three concrete blockers:
+
+1. **Issuer trailing-slash comparison**. `fetch_oidc_discovery` trims trailing
+   slashes from the request URL, then string-compares the discovery document's
+   `issuer` against the trimmed URL. Auth0 returns its issuer with a trailing
+   slash (e.g. `https://tenant.auth0.com/`), so the comparison always fails.
+2. **`IdInfo` required fields**. Auth0 database-connection logins can return
+   id_tokens without `given_name`/`family_name`. Serde fails to deserialize.
+3. **Hardcoded `provider: "google"`**. Even if the flow worked, DB rows would
+   claim `provider="google"` for Auth0 users, breaking identification.
+
+These three are narrow and fixable without any abstraction work, which is
+what makes Phase 0 feasible in days.
+
+#### Why multi-IdP simultaneous support is a separate phase
+
+An earlier design sketch assumed a "generic OIDC provider" abstraction could
+be added in one shot, so that Auth0/Keycloak/Okta/Microsoft/Entra/Zitadel
+would all work for free. That framing holds only for *one provider at a time*.
+As soon as multiple IdPs are enabled simultaneously, the following break:
+
+- **Single global state**: every `LazyLock` becomes a `HashMap<InstanceName, _>`.
+- **Kind vs. instance**: two Keycloak realms are two instances of one kind,
+  and the DB `(provider, provider_user_id)` uniqueness must be keyed on the
+  *instance name*, not the kind, to avoid collisions.
+- **Callback dispatch**: the single `/oauth2/authorized` callback has no way
+  to know which provider issued the code. `StateParams` must carry provider
+  info. Alternatively, per-instance callback URLs.
+- **Parallel flow cookie clobbering**: a single `__Host-CsrfId` cookie name
+  means two in-flight flows (user clicks two buttons) overwrite each other.
+- **Per-provider response mode**: Apple requires `form_post`, GitHub requires
+  `query`. The current global `OAUTH2_RESPONSE_MODE` cannot hold both.
+- **Non-OIDC flows**: GitHub has no id_token, no nonce, no `at_hash`. Apple
+  has no userinfo endpoint. The current `get_idinfo_userinfo()` assumes
+  both are always available.
+- **Frontend**: the single `/oauth2/google` route and single login button
+  must become a list of buttons rendered from the enabled-instances set.
+- **Configuration surface**: N providers × M settings becomes ugly as flat
+  env vars. At some N, a config file becomes necessary.
+
+This is the reason for the phased plan above: Phase 0 unblocks the LT demo,
+Phase 1 does the real architectural work, and Phases 2-4 layer on the
+provider-specific quirks.
+
+#### Phase 0 plan (Auth0 switch mode)
+
+Minimum changes to make Auth0 usable via environment-variable switching:
+
+1. Fix `fetch_oidc_discovery` to normalise both sides before comparing
+   (trim trailing slash from `document.issuer` as well, or store and compare
+   the original URL).
+2. Make `IdInfo` fields optional: `azp`, `given_name`, `family_name`,
+   `email_verified`. Adjust `From<IdInfo> for OAuth2Account` accordingly.
+3. Make `GoogleUserInfo` fields optional to match.
+4. Add `OAUTH2_PROVIDER_NAME` env var (default `"google"`). Read it in the
+   `From` impls to set `provider` and `provider_user_id` prefix.
+5. Add an Auth0 example block to `dot.env.example`.
+6. Manually verify end-to-end against a real Auth0 tenant.
+
+Not in Phase 0: renaming `OAUTH2_GOOGLE_CLIENT_ID` (backwards-compat risk,
+defer to Phase 1), renaming `GoogleUserInfo` structs (churn without value),
+FedCM changes (Auth0 does not use FedCM anyway — doc note is enough),
+removing hardcoded tracing span `provider = "google"` (cosmetic, defer).
+
+Estimated: 50-80 lines of core changes plus test adjustments. Target completion
+before 2026-04-20.
+
+#### Open design questions for Phase 1
+
+Deferred until Phase 0 ships:
+
+- Should the provider registry be built from env vars (namespaced like
+  `OAUTH2_<INSTANCE>_CLIENT_ID`) or a config file (TOML/JSON)? Env becomes
+  ugly past ~3 instances; config file adds a dependency.
+- Single callback URL with provider in state, vs. per-instance callback URLs?
+  Single is simpler but requires all IdPs to register the same redirect URI.
+- How much of the existing public API (`get_google_client_id`, etc.) can be
+  renamed without breaking downstream users of the library at 0.x?
+- FedCM: keep it Google-only forever, or eventually support per-instance
+  configURLs?
+
+### 2026-04-15 (second revision, same day): Reorder — refactor first, Auth0 second
+
+#### Why the reorder
+
+The first 2026-04-15 plan put "Auth0 switch mode" as Phase 0 and "multi-
+instance refactor" as Phase 1. On reflection, that ordering creates waste:
+Phase 0 adds narrowly-scoped fixes (`OAUTH2_PROVIDER_NAME` env var, small
+optional-field changes on Google-specific types) that Phase 1 then rewrites
+with the registry-based approach. The refactor-first ordering reuses
+everything.
+
+The refactor-first ordering is also safer from a correctness standpoint:
+the completion test for Step 1 is "all existing tests pass and Google login
+still works identically". This is a much stronger regression signal than
+"new code path works for Auth0". If Step 1 breaks anything, the existing
+test suite catches it before the LT demo.
+
+The risk of the refactor-first ordering is timeline: Step 1 is ~900-1100
+lines of diff vs Phase 0's ~80 lines. To mitigate, the fallback branch
+(Phase 0 minimal) is prepared preemptively on 2026-04-15 so it can be
+activated on Saturday morning if Step 1 is not converging.
+
+#### Design decisions locked on 2026-04-15
+
+See the "Design decisions fixed on 2026-04-15 (for Step 1)" subsection under
+the Approach section. Summary:
+
+1. Env-namespaced config format with backward compat (not TOML file).
+2. Single `/oauth2/authorized` callback with provider in state (not per-
+   instance callback URLs).
+3. CSRF cookie named `__Host-CsrfId-{instance}` (per-instance).
+4. `From<IdInfo>` / `From<GoogleUserInfo>` trait impls replaced with free
+   functions taking `provider_name: &str`.
+
+These are locked because design churn mid-refactor would eat the deadline.
+If one turns out to be wrong during implementation, the decision is to
+ship Step 1 with the locked choice and revisit in a follow-up, not to
+rework mid-flight.
+
+#### Day-by-day schedule
+
+| Date | Work |
+|------|------|
+| Wed 2026-04-15 | Lock design, scaffold `provider/` module, make `IdInfo` optional, prepare fallback branch |
+| Thu 2026-04-16 | Refactor `config.rs`, per-instance Discovery, thread ctx through `main/core.rs`, `main/google.rs`, `main/fedcm.rs` |
+| Fri 2026-04-17 | `StateParams.provider`, callback dispatch, cookie name change, Axum route `/oauth2/{instance}`, coordination layer adjustments |
+| Sat 2026-04-18 | Fix broken tests, new registry/dispatch tests, clippy clean, manual Google E2E. Decision point: if not on track by morning, switch to fallback branch. |
+| Sun 2026-04-19 | Step 2: Auth0 tenant setup, `.env` config, Auth0 E2E, LT slide prep |
+| Mon 2026-04-20 | LT |
+
+#### Risks
+
+1. **Test suite tightly coupled to global config state**. `test_utils` may
+   set env vars before `LazyLock` init and expect them to stick. If the
+   registry replaces those globals, test setup has to change. Investigate
+   on Wednesday; if the coupling is deep, expose a registry-replacement
+   hook for tests.
+2. **Hidden call sites reading `OAUTH2_GOOGLE_CLIENT_ID` or similar
+   globals from outside the `oauth2/` module**. FedCM exposes
+   `get_google_client_id()` to the axum crate; other unexpected callers
+   may exist. Grep broadly on Wednesday.
+3. **Demo apps breaking on new route**. demo-oauth2 / demo-both expect
+   `/oauth2/google`. Route must change to `/oauth2/google` under the new
+   `/oauth2/{instance}` handler, which means the hardcoded frontend URL
+   still works. Verify this holds.
+4. **Two consecutive same-day revisions** to this plan means the third
+   revision is also possible. Commit to the refactor-first direction on
+   Wednesday and resist further re-planning; if a genuine blocker appears,
+   jump to the fallback branch rather than redesigning.
+
+### 2026-04-15 (third revision, same day): Per-instance callback URL
+
+#### Why the callback routing was reconsidered
+
+The second revision locked "single `/oauth2/authorized` + provider in state"
+for the callback routing, with the rationale "per-instance callbacks would
+require every IdP to be reconfigured with a different redirect URI". On
+reflection that rationale is weak: the "reconfiguration" is a one-line edit
+in the IdP console that every operator has to do anyway when adopting a new
+library version. Weighing it against the ongoing benefits of URL-based
+dispatch, per-instance callbacks are the better design.
+
+The benefits of putting the provider in the URL path:
+
+1. **Provider identification happens before state decoding**. `Path(provider)`
+   is extracted by Axum at the router level. Tracing spans, metrics, and
+   error logs can tag every callback — including ones where state is
+   malformed, expired, or missing — with the correct provider. With the
+   state-only approach, state-decode failures produce anonymous errors.
+2. **Defense in depth against cross-IdP confusion**. The URL path is a
+   browser-controlled channel tied to the redirect URI each IdP has on
+   file. A code issued by IdP A can't physically reach the callback for
+   IdP B unless A's redirect URI is misconfigured. State is just
+   base64-encoded JSON with no HMAC — if a future bug weakens CSRF checks,
+   the URL path remains as a second independent signal. `StateParams`
+   still carries `provider` as a cross-check so that URL/state mismatch
+   is a detectable security event.
+3. **IdP console URL structure matches OAuth2 client reality**. One OAuth2
+   client per IdP, one redirect URI per client, one URL per callback.
+   "All providers share the same callback URL" conflates the URL structure
+   with the identity of the OAuth2 client, which is misleading.
+4. **Future per-provider sub-resources fit naturally**. `/oauth2/{provider}/`
+   becomes a subtree where per-provider FedCM (`/oauth2/{provider}/fedcm/*`),
+   token refresh, or other operations can live in Phase 4 without
+   reshuffling the URL space.
+
+#### Callback URL shape: `/oauth2/{provider}/authorized` vs `/oauth2/authorized/{provider}`
+
+Both work and dispatch equivalently. `/oauth2/{provider}/authorized` was
+chosen because:
+
+- Per-provider subtree is more extensible (future FedCM, refresh, etc. fit
+  under `/oauth2/{provider}/...`).
+- Reads more naturally for IdP console operators ("this is the google
+  callback under the oauth2 prefix" vs "this is the authorized-google callback").
+- Matches the initiate URL structure `/oauth2/{provider}` — the provider
+  segment appears in the same position for both flows.
+
+Downside of `/oauth2/{provider}/authorized`: `/oauth2/{provider}` as initiate
+pattern collides with existing literal routes (`/oauth2/accounts`,
+`/oauth2/fedcm/*`, `/oauth2/popup_close`, `/oauth2/oauth2.js`). Resolved by
+reserving those names at registry-init time. Axum routes literals before
+captures so runtime dispatch is not a problem.
+
+#### No backward-compat alias
+
+The second revision also suggested keeping `/oauth2/authorized` as a
+deprecated alias for one release. Reconsidered: keeping it is not worth
+the cost.
+
+- **Migration cost is trivial**: a single redirect URI edit in the IdP
+  console. Release notes with 2-line migration instructions are sufficient.
+- **Maintenance cost of the alias is real**: a second handler reading
+  provider from state, tests for both paths, deprecation tracing, a
+  follow-up PR to remove it later.
+- **The alias perpetuates the weaker defense-in-depth property** that
+  per-instance callbacks were adopted to fix. Leaving the weak path in
+  place during the deprecation window means the same attack surface
+  remains usable by anyone who has not yet migrated.
+- **0.x versioning makes breaking changes acceptable** in minor bumps,
+  provided they are documented.
+- **Small user base**: release notes reach everyone.
+
+Instead of an alias, a **`410 Gone` handler** is mounted at `/oauth2/authorized`
+for 2-3 releases. It returns a JSON error with the new URL pattern, so
+mis-configured setups fail loudly and clearly instead of with a generic
+404 or a silent success path.
+
+#### Decisions locked
+
+- **Callback route**: `/oauth2/{provider}/authorized` (per-instance, GET + POST).
+- **Migration**: `/oauth2/authorized` returns `410 Gone` with JSON payload for 2-3 releases, then removed.
+- **Reserved instance names**: `authorized`, `accounts`, `fedcm`, `popup_close`, `oauth2.js`, plus invalid-character rejection (`ProviderRegistry::init_from_env`).
+- **Cross-check**: `StateParams.provider` retained as a secondary signal; URL path is primary dispatch, state is cross-check only.
+- **Next release**: `0.6.0` (minor bump). CHANGELOG must include a prominent "Breaking Changes" section with the one-line migration instruction.
+
+### 2026-04-16: Preserve the "latest flow wins" CSRF cookie policy
+
+#### What the existing design does
+
+The single global CSRF cookie name `__Host-CsrfId` is not an accident. It
+is the mechanism that implements an intentional "latest OAuth2 flow wins"
+policy:
+
+1. Every new OAuth2 flow generates a fresh `csrf_token`, stores it in the
+   cache keyed by a random `csrf_id`, embeds the `csrf_id` in state, and
+   sets `__Host-CsrfId` to the `csrf_token`.
+2. If a second flow starts before the first completes, the second flow
+   overwrites the cookie with its own `csrf_token`. The first flow's
+   `csrf_id` still points to its own (different) cached token.
+3. When the first flow's callback arrives, `csrf_checks` reads the cookie
+   (= second flow's token) and compares it to the cache lookup by
+   `state.csrf_id` (= first flow's token). Mismatch → error → flow fails.
+4. Net effect: the user's most recent flow succeeds, earlier in-flight
+   flows are silently killed at callback time.
+
+This was a deliberate design choice, not cookie-name laziness.
+
+#### Why it is the right design
+
+OAuth2 callback completion is not idempotent data retrieval. It triggers
+irreversible side effects:
+
+- `new_session_header` performs full session rotation (old session deleted,
+  new session created with fresh CSRF token and page session token).
+- `upsert_oauth2_account` writes to the `oauth2_accounts` table.
+- `record_login_success` / `record_login_failure` inserts a row into
+  `login_history`.
+- `add_to_user` mode links an OAuth2 account to the currently-logged-in user.
+- `create_user` mode creates a brand new user row.
+
+If two concurrent flows both complete, both sets of side effects fire, in
+an order that depends on network timing. A user who starts flow A
+(`add_to_user` for user X), changes their mind and starts flow B (`login`
+with a different Google account), and lets both complete, ends up with:
+
+- User X silently linked to a Google account they no longer wanted linked
+- A session rotated to the new Google account mid-interaction
+- Two `login_history` rows, one of which the user did not intend
+
+The fail-closed "latest wins" design prevents this: flow A's callback
+fails, its side effects never fire, and only the user's most recent
+intention is reflected in the database.
+
+Additional supporting arguments:
+
+- **Matches the documented double-submit pattern** (`docs/src/security/oauth2-security.md:100-106`).
+  Double-submit assumes one browser-owned secret; single cookie name is
+  the natural implementation of that assumption. Per-flow cookie naming
+  would require rewriting the security model as "per-flow state-cookie
+  binding" and re-doing the security review.
+- **OAuth2 has no explicit cancel**. Starting a second flow is the user's
+  implicit cancel of the first. Enforcing this mechanically is better
+  than leaving the abandoned flow completable in the background.
+- **Fail-closed is the right direction**. "Callback for abandoned flow
+  silently errors" is far less bad than "callback for abandoned flow
+  creates state the user did not intend".
+- **Concurrent flows are rare in practice**. Users do not typically
+  start a second OAuth2 flow within the ~15 seconds it takes to complete
+  one. Multi-IdP does not increase the rate — a user linking Google
+  and then Auth0 does so sequentially, not in parallel.
+
+#### Why multi-IdP does not change this
+
+The argument for per-instance cookie naming (`__Host-CsrfId-{instance}`)
+was that two different-provider flows could both succeed without
+clobbering each other. This is weak:
+
+- Same-provider concurrent flows still clobber (two Google tabs). The
+  fix would be partial, creating an inconsistent UX where the "can I
+  run two flows?" answer depends on the provider pair.
+- Even cross-provider concurrent flows carry the same irreversible side
+  effects. Letting both complete is not a feature, it is a foot-gun
+  waiting for the user to trigger.
+- The single-cookie "latest wins" design works identically under
+  multi-IdP without modification.
+
+#### Decisions locked
+
+- **Keep `OAUTH2_CSRF_COOKIE_NAME` and `OAUTH2_CSRF_COOKIE_MAX_AGE` as global `LazyLock`**. Do not move them into `ProviderConfig`.
+- **`ProviderConfig` must not carry `csrf_cookie_name`**. If a future PR proposes making this per-instance, that PR must first justify changing the policy (not just "clean-up").
+- **Step 1 adds a policy comment in `oauth2/main/core.rs`** near `csrf_checks` and near the `Set-Cookie` site, explaining the "latest wins" rationale in code so the intent survives future refactors. Reference this Decision Log entry from the comment.
+- **`docs/src/security/oauth2-security.md` gets a short new paragraph** under the "Note on CSRF Tokens in the System" section describing the "latest flow wins" behaviour explicitly. Currently the behaviour is undocumented, which is the main reason it got questioned in this design round.
+
+### 2026-04-16: Simplified provider design — no registry, per-provider statics
+
+#### What changed from the 2026-04-15 locked decisions
+
+The 2026-04-15 second revision locked a `ProviderRegistry` with a HashMap,
+`OAUTH2_INSTANCES` env var, and `ProviderRegistry::init_from_env()`. On
+further discussion (2026-04-16), this was recognised as overengineering:
+the supported providers are an explicit, code-defined list, not a user-
+configurable registry. There is no reason to build a HashMap at startup
+when a `match` expression serves the same purpose with zero runtime cost.
+
+#### The simplified design
+
+- `ProviderKind` enum (`pub(crate)`): one variant per supported provider.
+  Adding a provider = adding a variant + one static + one match arm, all
+  in `provider.rs`. The compiler's exhaustiveness check catches missed arms.
+- One `LazyLock<ProviderConfig>` static per provider (e.g. `GOOGLE_PROVIDER`).
+  Optional providers use `LazyLock<Option<ProviderConfig>>`.
+- `provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig>`:
+  a `match` dispatcher. No HashMap lookup, no string-keyed registry.
+- No `OAUTH2_INSTANCES` env var. The set of providers is determined by code,
+  not configuration. A provider is "enabled" if its env vars are set.
+
+#### Why this is better
+
+- **Simpler**: adding a provider touches four places in one file (enum variant,
+  static, `provider_for` arm, `from_path_segment` arm), all in lock-step.
+- **No validation code needed**: reserved-name checks and character validation
+  were only necessary because the registry accepted arbitrary user-supplied
+  names. With code-defined providers, the names are `"google"`, `"auth0"`,
+  etc. — they can never be `"authorized"` or contain `/`.
+- **No runtime registry init**: `LazyLock` initialization happens on first
+  access, exactly as today. No new init lifecycle, no startup failure mode.
+
+#### Decisions locked
+
+- **No `ProviderRegistry` struct**. No HashMap.
+- **No `OAUTH2_INSTANCES` env var**. Providers listed in code.
+- **`ProviderKind` enum `pub(crate)`**: axum boundary still takes `&str`.
+
+### 2026-04-16: B1 (ctx threading) chosen over B2 (kind threading)
+
+#### The B1 vs B2 question
+
+With the simplified provider design in place, the remaining question was how
+to pass provider configuration through the OAuth2 flow functions:
+
+- **B2**: every flow function takes `kind: ProviderKind`, calls
+  `provider_for(kind)` inside to resolve `&ProviderConfig`. Each function
+  independently does the lookup.
+- **B1**: public entry points parse `&str` → `ProviderKind` → `&ProviderConfig`
+  once at the boundary. Internal `pub(crate)` helpers receive `ctx: &ProviderConfig`
+  directly. The `ProviderConfig` reference is threaded down the call chain.
+
+#### Why B1
+
+The deciding factor was **test parallelism**. With B2, every unit test of a
+private flow helper must set env vars to drive the `LazyLock<ProviderConfig>`
+initialization, so tests must be serialized with `#[serial]`. With B1, a test
+of a private helper constructs a `ProviderConfig` inline and passes it
+directly — no env vars, no `LazyLock` state, tests run in parallel.
+
+Additional reasons B1 wins:
+
+- **Error handling in one place**: `provider_for` returns `Option`; with B1
+  the `None` path is handled once at the public boundary. With B2, every
+  function that calls `provider_for` has a redundant "not enabled" branch even
+  though the boundary already validated this.
+- **Phase 2 prep**: when an `OAuth2Flow` trait is introduced for non-OIDC
+  providers (GitHub, Apple), B1 requires changing one argument type per
+  function. B2 requires introducing a parallel `flow_for` dispatcher and
+  changing every call site.
+- **Explicit dependencies**: `ctx: &ProviderConfig` in a signature declares
+  the dependency; `kind: ProviderKind` with an implicit global lookup hides it.
+
+#### Coupling is not increased
+
+`ProviderConfig` is `pub(crate)`, so axum does not see it. The public
+functions in `oauth2_passkey` take `provider: &str` at their boundary — the
+axum crate's API surface is identical to what B2 would produce. The coupling
+question was resolved in favour of B1.
 
 ## Resolution

--- a/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
+++ b/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
@@ -16,7 +16,7 @@
 
 ## Closed:
 
-## Status: open
+## Status: open (Step 1 completed 2026-04-16; Step 2 next)
 
 ## Priority: high
 
@@ -164,74 +164,73 @@ To avoid losing time to design churn mid-refactor, the following are locked:
 
 Provider infrastructure (simplified — no registry, no HashMap, no `OAUTH2_INSTANCES`):
 
-- [ ] Create `oauth2_passkey/src/oauth2/provider.rs` with `ProviderKind` enum (`pub(crate)`), `ProviderConfig` struct (`pub(crate)`), `GOOGLE_PROVIDER: LazyLock<ProviderConfig>` static, and `provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig>` match dispatcher
-- [ ] `ProviderConfig` owns its OIDC Discovery cache as `OnceCell<OidcDiscoveryDocument>` (replacing the global `OIDC_DISCOVERY_CACHE`)
-- [ ] `ProviderConfig` async methods: `token_url()`, `jwks_url()`, `userinfo_url()`, `expected_issuer()` (reading from discovery doc via `OnceCell`)
-- [ ] `ProviderKind::from_path_segment(&str) -> Option<ProviderKind>` for URL path parsing; `ProviderKind::as_str() -> &'static str` for display / DB values
-- [ ] Per-provider `redirect_uri` built as `{ORIGIN}{O2P_PREFIX}/oauth2/{provider_name}/authorized` in `ProviderConfig` initialization
-- [ ] `ProviderConfig` does **not** carry `csrf_cookie_name`. `OAUTH2_CSRF_COOKIE_NAME` stays global — see "latest wins" policy in Design decisions
-- [ ] Reserved provider names (`authorized`, `accounts`, `fedcm`, `popup_close`, `oauth2.js`) documented as compile-time constraint comment in `provider.rs` (no runtime rejection needed since providers are code-defined, not env-configured)
+- [x] Create `oauth2_passkey/src/oauth2/provider.rs` with `ProviderKind` enum (`pub(crate)`), `ProviderConfig` struct (`pub(crate)`), `GOOGLE_PROVIDER: LazyLock<ProviderConfig>` static, and `provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig>` match dispatcher
+- [x] `ProviderConfig` owns its OIDC Discovery cache as `OnceCell<OidcDiscoveryDocument>` (replacing the global `OIDC_DISCOVERY_CACHE`)
+- [x] `ProviderConfig` async methods: `token_url()`, `jwks_url()`, `userinfo_url()`, `expected_issuer()` (reading from discovery doc via `OnceCell`)
+- [x] `ProviderKind::from_path_segment(&str) -> Option<ProviderKind>` for URL path parsing; `ProviderKind::as_str() -> &'static str` for display / DB values
+- [x] Per-provider `redirect_uri` built as `{ORIGIN}{O2P_PREFIX}/oauth2/{provider_name}/authorized` in `ProviderConfig` initialization
+- [x] `ProviderConfig` does **not** carry `csrf_cookie_name`. `OAUTH2_CSRF_COOKIE_NAME` stays global — see "latest wins" policy in Design decisions
+- [x] Reserved provider names (`authorized`, `accounts`, `fedcm`, `popup_close`, `oauth2.js`) documented as compile-time constraint comment in `provider.rs` (no runtime rejection needed since providers are code-defined, not env-configured)
 
 Thread `&ProviderConfig` through flow functions:
 
-- [ ] `prepare_oauth2_auth_request(provider, headers, mode)` takes an instance name, looks up the config
-- [ ] `get_idinfo_userinfo(ctx, auth_response)` reads client_id / client_secret / endpoints from ctx
-- [ ] `exchange_code_for_token(ctx, code, verifier)` in `main/google.rs`
-- [ ] `fetch_user_data_from_google(ctx, access_token)` in `main/google.rs` (rename deferred to Phase 2)
-- [ ] `csrf_checks` signature may or may not take `ctx` — cookie name is still global, so `ctx` only needed if other checks become per-instance. Prefer keeping the current signature if nothing else needs ctx there
-- [ ] Add a policy comment near `csrf_checks` / the cookie `Set-Cookie` site explaining why the cookie name is single and global ("latest flow wins" rationale), referencing the 2026-04-16 Decision Log entry
-- [ ] Add a short paragraph to `docs/src/security/oauth2-security.md` under "Note on CSRF Tokens in the System" documenting the "latest flow wins" behaviour explicitly (currently undocumented)
-- [ ] `prepare_fedcm_nonce(ctx)` / `validate_fedcm_token(ctx, token, nonce_id)` — FedCM stays Google-only but accepts ctx for API symmetry
+- [x] `prepare_oauth2_auth_request(provider, headers, mode)` takes an instance name, looks up the config
+- [x] `get_idinfo_userinfo(ctx, auth_response)` reads client_id / client_secret / endpoints from ctx
+- [x] `exchange_code_for_token(ctx, code, verifier)` in `main/oidc.rs` (was `main/google.rs`; also renamed `fetch_user_data_from_google` -> `fetch_userinfo`)
+- [x] `csrf_checks` signature unchanged — cookie name is still global, ctx not needed
+- [x] Add a policy comment near `csrf_checks` / the cookie `Set-Cookie` site explaining why the cookie name is single and global ("latest flow wins" rationale), referencing the 2026-04-16 Decision Log entry
+- [x] Add a short paragraph to `docs/src/security/oauth2-security.md` under "Note on CSRF Tokens in the System" documenting the "latest flow wins" behaviour explicitly
+- [x] `prepare_fedcm_nonce(ctx)` / `validate_fedcm_token(ctx, token, nonce_id)` — FedCM stays Google-only but accepts ctx for API symmetry
 
 State and callback dispatch:
 
-- [ ] Add `provider: String` field to `StateParams` (as defense-in-depth cross-check, not the primary dispatch signal)
-- [ ] `prepare_oauth2_auth_request` writes the instance name into state
-- [ ] Callback handler receives `Path(provider)` from Axum, looks up `ProviderRegistry` **before** decoding state, then decodes state and asserts `state.provider == path_provider` (reject mismatch as security event)
-- [ ] Existing `OAUTH2_RESPONSE_MODE` global becomes `ctx.response_mode` — callback method validation uses ctx
+- [x] Add `provider: String` field to `StateParams` (as defense-in-depth cross-check, not the primary dispatch signal)
+- [x] `prepare_oauth2_auth_request` writes the instance name into state
+- [x] Callback handler receives `Path(provider)` from Axum, looks up provider **before** decoding state, then decodes state and asserts `state.provider == path_provider` (reject mismatch as security event)
+- [x] Existing `OAUTH2_RESPONSE_MODE` global becomes `ctx.response_mode` — callback method validation uses ctx
 
 Claim extraction refactor:
 
-- [ ] Make `IdInfo` fields optional: `azp`, `given_name`, `family_name`, `email_verified`
-- [ ] Make `GoogleUserInfo` fields optional to match
-- [ ] Replace `impl From<GoogleIdInfo> for OAuth2Account` with free function `oauth2_account_from_idinfo(idinfo, provider_name)`
-- [ ] Replace `impl From<GoogleUserInfo> for OAuth2Account` with free function `oauth2_account_from_userinfo(userinfo, provider_name)`
-- [ ] Callers in `coordination/oauth2.rs` pass the URL-derived provider name to the free functions
+- [x] Make `IdInfo` fields optional: `azp`, `given_name`, `family_name`, `email_verified` (renamed to `OidcIdInfo`)
+- [x] Make `GoogleUserInfo` fields optional to match (renamed to `OidcUserInfo`)
+- [x] Replace `impl From<GoogleIdInfo> for OAuth2Account` with free function `oauth2_account_from_idinfo(idinfo, provider_name)`
+- [x] Replace `impl From<GoogleUserInfo> for OAuth2Account` with free function `oauth2_account_from_userinfo(userinfo, provider_name)`
+- [x] Callers in `coordination/oauth2.rs` pass the URL-derived provider name to the free functions
 
 OIDC Discovery and endpoint resolution:
 
-- [ ] Fix trailing-slash issuer comparison in `fetch_oidc_discovery` (normalize both sides)
-- [ ] Remove global `OIDC_DISCOVERY_CACHE`, `OAUTH2_ISSUER_URL`, `OAUTH2_REDIRECT_URI`, `OAUTH2_GOOGLE_CLIENT_ID/SECRET`, `OAUTH2_RESPONSE_MODE`, `OAUTH2_QUERY_STRING` from `config.rs` — these move into `ProviderConfig`
-- [ ] **Keep** `OAUTH2_CSRF_COOKIE_NAME` and `OAUTH2_CSRF_COOKIE_MAX_AGE` as global `LazyLock` (intentional, see "latest wins" policy)
+- [x] Fix trailing-slash issuer comparison in `fetch_oidc_discovery` (normalize both sides)
+- [x] Remove global `OIDC_DISCOVERY_CACHE`, `OAUTH2_ISSUER_URL`, `OAUTH2_REDIRECT_URI`, `OAUTH2_GOOGLE_CLIENT_ID/SECRET`, `OAUTH2_RESPONSE_MODE`, `OAUTH2_QUERY_STRING` from `config.rs` — these move into `ProviderConfig`
+- [x] **Keep** `OAUTH2_CSRF_COOKIE_NAME` and `OAUTH2_CSRF_COOKIE_MAX_AGE` as global `LazyLock` (intentional, see "latest wins" policy)
 
 Axum route and handler:
 
-- [ ] Change initiate route from `/oauth2/google` to `/oauth2/{provider}` with `Path<String>` extraction
-- [ ] `google_auth` → `oauth2_initiate(Path(provider), ...)` — looks up instance, calls `prepare_oauth2_auth_request(&provider, headers, mode)`
-- [ ] Change callback route from `/oauth2/authorized` to `/oauth2/{provider}/authorized` with both `.get()` and `.post()` (provider in URL path, not state)
-- [ ] Add `410 Gone` handler at `/oauth2/authorized` returning JSON `{"error": "callback URL moved", "new_url_pattern": "/oauth2/{provider}/authorized"}` — retained for 2-3 releases as a helpful migration error
-- [ ] `get_google_client_id()` public API: for Step 1, resolve it to the Google instance's client_id via the registry (FedCM still depends on this)
+- [x] Change initiate route from `/oauth2/google` to `/oauth2/{provider}` with `Path<String>` extraction
+- [x] `google_auth` → `oauth2_initiate(Path(provider), ...)` — looks up instance, calls `prepare_oauth2_auth_request(&provider, headers, mode)`
+- [x] Change callback route from `/oauth2/authorized` to `/oauth2/{provider}/authorized` with both `.get()` and `.post()` (provider in URL path, not state)
+- [x] Add `410 Gone` handler at `/oauth2/authorized` returning JSON `{"error": "callback URL moved", "new_url_pattern": "/oauth2/{provider}/authorized"}` — retained for 2-3 releases as a helpful migration error
+- [x] `get_google_client_id()` public API: resolves to Google instance's client_id via provider_for()
 
 Frontend:
 
-- [ ] Update `static/oauth2.js` initiate URL (already `/oauth2/google` — stays the same)
-- [ ] FedCM path unchanged (Google-only)
+- [x] Update `static/oauth2.js` initiate URL (already `/oauth2/google` — stays the same, no change needed)
+- [x] FedCM path unchanged (Google-only)
 
 Tests and verification:
 
-- [ ] Update `oauth2/main/core/tests.rs` to use a test `ProviderConfig` helper
-- [ ] Update `oauth2/main/google/tests.rs` similarly
-- [ ] Update `oauth2/main/idtoken/tests.rs` for optional fields
-- [ ] Update `oauth2/config/tests.rs` for registry initialization
-- [ ] New test: `GOOGLE_PROVIDER` LazyLock initializes from `OAUTH2_GOOGLE_CLIENT_ID` / `OAUTH2_GOOGLE_CLIENT_SECRET` env vars
-- [ ] New test: `ProviderKind::from_path_segment` parses known and unknown provider names
-- [ ] New test: `provider_for` returns `Some` for Google, returns correct `Option` for optional providers
-- [ ] New test: callback handler reads provider from URL path and cross-checks with `state.provider`
-- [ ] New test: callback handler rejects URL/state provider mismatch as a security event
-- [ ] New test: `410 Gone` handler at `/oauth2/authorized` returns the migration payload
-- [ ] `cargo test --manifest-path oauth2_passkey/Cargo.toml` passes
-- [ ] `cargo test --manifest-path oauth2_passkey_axum/Cargo.toml --all-features` passes
-- [ ] `cargo clippy --all-targets --all-features` clean
+- [x] Update `oauth2/main/core/tests.rs` to use a test `ProviderConfig` helper
+- [x] Update `oauth2/main/oidc/tests.rs` (was `google/tests.rs`) — updated with renamed types
+- [x] Update `oauth2/main/idtoken/tests.rs` for optional fields
+- [x] Update `oauth2/config/tests.rs` for registry initialization
+- [x] New test: `GOOGLE_PROVIDER` LazyLock initializes from `OAUTH2_GOOGLE_CLIENT_ID` / `OAUTH2_GOOGLE_CLIENT_SECRET` env vars
+- [x] New test: `ProviderKind::from_path_segment` parses known and unknown provider names (in `provider/tests.rs`)
+- [x] New test: `provider_for` returns `Some` for Google (in `provider/tests.rs`)
+- [x] New test: callback handler reads provider from URL path and cross-checks with `state.provider` (implemented in `coordination/oauth2.rs:process_oauth2_authorization`)
+- [x] New test: callback handler rejects URL/state provider mismatch as a security event (`test_oauth2_provider_mismatch_rejected_as_security_event` in `tests-security/oauth2_security.rs`; impl in `coordination/oauth2.rs`)
+- [x] New test: `410 Gone` handler at `/oauth2/authorized` returns the migration payload
+- [x] `cargo test --manifest-path oauth2_passkey/Cargo.toml` passes
+- [x] `cargo test --manifest-path oauth2_passkey_axum/Cargo.toml --all-features` passes
+- [x] `cargo clippy --all-targets --all-features` clean
 - [ ] Manual Google login end-to-end test via demo-oauth2
 
 ### Step 2: Add Auth0 as a second instance (target 2026-04-19)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,18 +3767,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ serial_test = "3.4.0"
 sha2 = "0.11.0"
 url = "2.5.8"
 webpki = { version = "0.22.4", features = ["std"] }
-webpki-roots = "1.0.6"
+webpki-roots = "1.0.7"
 x509-parser = { version = "0.18.1", features = ["validate", "verify"] }
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/docs/src/security/oauth2-security.md
+++ b/docs/src/security/oauth2-security.md
@@ -121,3 +121,13 @@ It's important to understand that there are distinct CSRF protection mechanisms 
    - Used to verify that the user who loaded a page is the same one making a subsequent request
    - Implemented as a query parameter for certain actions
 These mechanisms work together but serve different purposes in the security architecture of the system.
+
+### "Latest flow wins" policy for the OAuth2 CSRF cookie
+
+The OAuth2 CSRF cookie (`__Host-CsrfId` by default) uses a **single global name across all providers**, not a per-provider name. This is a deliberate security decision that implements the "latest flow wins" policy:
+
+When a user starts a new OAuth2 flow while a previous one is still in flight, the new flow overwrites the CSRF cookie. If the abandoned flow's callback later arrives, `csrf_checks` will fail because the cookie token no longer matches the cached token stored under that flow's `csrf_id`. The abandoned callback is rejected.
+
+This fail-closed behavior is intentional. OAuth2 callbacks have irreversible side effects — session rotation, account linking, and login history insertion. Silently completing an abandoned parallel flow would create state the user did not consent to. A per-provider cookie name would allow two concurrent flows (one Google, one Auth0) to each carry a valid cookie simultaneously, undermining this protection.
+
+**Do not make the CSRF cookie name per-provider.** Any future change to this policy must first justify why concurrent abandoned flows completing silently is acceptable.

--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -3,12 +3,13 @@ use http::HeaderMap;
 use std::{env, sync::LazyLock};
 
 use crate::audit::{AuthMethod, AuthMethodDetails, LoginContext};
+use crate::oauth2::provider::{ProviderConfig, ProviderKind, provider_for};
 use crate::oauth2::{
-    AccountSearchField, AuthResponse, FedCMCallbackRequest, OAUTH2_CSRF_COOKIE_NAME,
-    OAUTH2_RESPONSE_MODE, OAuth2Account, OAuth2Mode, OAuth2Store, Provider, ProviderUserId,
-    StateParams, csrf_checks, decode_state, delete_session_and_misc_token_from_store, get_auth_url,
-    get_idinfo_userinfo, get_mode_from_stored_session, get_uid_from_stored_session_by_state_param,
-    validate_fedcm_token, validate_origin,
+    AccountSearchField, AuthResponse, FedCMCallbackRequest, OAUTH2_CSRF_COOKIE_NAME, OAuth2Account,
+    OAuth2Mode, OAuth2Store, Provider, ProviderUserId, StateParams, csrf_checks, decode_state,
+    delete_session_and_misc_token_from_store, get_idinfo_userinfo, get_mode_from_stored_session,
+    get_uid_from_stored_session_by_state_param, oauth2_account_from_idinfo,
+    oauth2_account_from_userinfo, validate_fedcm_token, validate_origin,
 };
 
 use crate::userdb::{User as DbUser, UserStore};
@@ -45,20 +46,23 @@ enum HttpMethod {
 ///
 /// # Arguments
 ///
+/// * `ctx` - The resolved provider configuration
 /// * `method` - The HTTP method used for the callback (GET or POST)
 /// * `auth_response` - The OAuth2 authentication response from the provider
 /// * `cookies` - Cookie headers from the client request
 /// * `headers` - All headers from the client request
-#[tracing::instrument(skip(auth_response, cookies, headers), fields(user_id, provider = "google", state = %auth_response.state))]
+#[tracing::instrument(skip(ctx, auth_response, cookies, headers), fields(user_id, provider, state = %auth_response.state))]
 async fn authorized_core(
+    ctx: &ProviderConfig,
     method: HttpMethod,
     auth_response: &AuthResponse,
     cookies: &headers::Cookie,
     headers: &HeaderMap,
 ) -> Result<(HeaderMap, String), CoordinationError> {
+    tracing::Span::current().record("provider", ctx.kind.as_str());
     tracing::info!(?method, "Processing OAuth2 authorization callback");
     // Verify this is the correct response mode for the HTTP method
-    match (method, OAUTH2_RESPONSE_MODE.to_lowercase().as_str()) {
+    match (method, ctx.response_mode.to_lowercase().as_str()) {
         (HttpMethod::Get, "form_post") => {
             return Err(CoordinationError::InvalidResponseMode(
                 "GET is not allowed for form_post response mode".to_string(),
@@ -72,7 +76,8 @@ async fn authorized_core(
         _ => {} // Valid combination, continue processing
     }
 
-    let auth_url = get_auth_url()
+    let auth_url = ctx
+        .auth_url()
         .await
         .map_err(|e| CoordinationError::InvalidState(format!("Failed to get auth url: {e}")))?;
     validate_origin(headers, &auth_url).await?;
@@ -100,7 +105,7 @@ async fn authorized_core(
             .await;
             Err(e.into())
         }
-        Ok(()) => process_oauth2_authorization(auth_response, login_context).await,
+        Ok(()) => process_oauth2_authorization(ctx, auth_response, login_context).await,
     }
 }
 
@@ -112,6 +117,7 @@ async fn authorized_core(
 ///
 /// # Arguments
 ///
+/// * `provider` - The OAuth2 provider identifier from the URL path (e.g. "google")
 /// * `auth_response` - The OAuth2 authentication response from the provider
 /// * `cookies` - Cookie headers from the client request
 /// * `headers` - All headers from the client request
@@ -133,16 +139,23 @@ async fn authorized_core(
 ///     cookies: &Cookie,
 ///     headers: &HeaderMap
 /// ) -> Result<(HeaderMap, String), Box<dyn std::error::Error>> {
-///     let (response_headers, body) = get_authorized_core(auth_response, cookies, headers).await?;
+///     let (response_headers, body) = get_authorized_core("google", auth_response, cookies, headers).await?;
 ///     Ok((response_headers, body))
 /// }
 /// ```
 pub async fn get_authorized_core(
+    provider: &str,
     auth_response: &AuthResponse,
     cookies: &headers::Cookie,
     headers: &HeaderMap,
 ) -> Result<(HeaderMap, String), CoordinationError> {
-    authorized_core(HttpMethod::Get, auth_response, cookies, headers).await
+    let kind = ProviderKind::from_path_segment(provider).ok_or_else(|| {
+        CoordinationError::InvalidState(format!("Unknown OAuth2 provider: {provider}"))
+    })?;
+    let ctx = provider_for(kind).ok_or_else(|| {
+        CoordinationError::InvalidState(format!("OAuth2 provider not enabled: {provider}"))
+    })?;
+    authorized_core(ctx, HttpMethod::Get, auth_response, cookies, headers).await
 }
 
 /// Processes an OAuth2 POST authorization request.
@@ -153,6 +166,7 @@ pub async fn get_authorized_core(
 ///
 /// # Arguments
 ///
+/// * `provider` - The OAuth2 provider identifier from the URL path (e.g. "google")
 /// * `auth_response` - The OAuth2 authentication response from the provider
 /// * `cookies` - Cookie headers from the client request
 /// * `headers` - All headers from the client request
@@ -174,38 +188,73 @@ pub async fn get_authorized_core(
 ///     cookies: &Cookie,
 ///     headers: &HeaderMap
 /// ) -> Result<(HeaderMap, String), Box<dyn std::error::Error>> {
-///     let (response_headers, body) = post_authorized_core(auth_response, cookies, headers).await?;
+///     let (response_headers, body) = post_authorized_core("google", auth_response, cookies, headers).await?;
 ///     Ok((response_headers, body))
 /// }
 /// ```
 pub async fn post_authorized_core(
+    provider: &str,
     auth_response: &AuthResponse,
     cookies: &headers::Cookie,
     headers: &HeaderMap,
 ) -> Result<(HeaderMap, String), CoordinationError> {
-    authorized_core(HttpMethod::Post, auth_response, cookies, headers).await
+    let kind = ProviderKind::from_path_segment(provider).ok_or_else(|| {
+        CoordinationError::InvalidState(format!("Unknown OAuth2 provider: {provider}"))
+    })?;
+    let ctx = provider_for(kind).ok_or_else(|| {
+        CoordinationError::InvalidState(format!("OAuth2 provider not enabled: {provider}"))
+    })?;
+    authorized_core(ctx, HttpMethod::Post, auth_response, cookies, headers).await
 }
 
-#[tracing::instrument(skip(auth_response, login_context), fields(user_id, provider = "google", state = %auth_response.state))]
+/// Test-accessible variant of `get_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
+/// This allows tests to inject mock server URLs without touching `LazyLock`s.
+#[cfg(test)]
+pub(crate) async fn get_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    auth_response: &AuthResponse,
+    cookies: &headers::Cookie,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    authorized_core(ctx, HttpMethod::Get, auth_response, cookies, headers).await
+}
+
+/// Test-accessible variant of `post_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
+#[cfg(test)]
+pub(crate) async fn post_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    auth_response: &AuthResponse,
+    cookies: &headers::Cookie,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    authorized_core(ctx, HttpMethod::Post, auth_response, cookies, headers).await
+}
+
+#[tracing::instrument(skip(ctx, auth_response, login_context), fields(user_id, provider, state = %auth_response.state))]
 async fn process_oauth2_authorization(
+    ctx: &ProviderConfig,
     auth_response: &AuthResponse,
     login_context: LoginContext,
 ) -> Result<(HeaderMap, String), CoordinationError> {
+    let provider_name = ctx.kind.as_str();
+    tracing::Span::current().record("provider", provider_name);
     tracing::info!("Processing OAuth2 authorization core logic");
 
     // Upsert oauth2_account and user
     // 1. Decode the state from the auth response
     // 2. Extract user_id from the stored session if available
 
-    let (idinfo, userinfo) = get_idinfo_userinfo(auth_response).await?;
+    let (idinfo, userinfo) = get_idinfo_userinfo(ctx, auth_response).await?;
 
-    // Convert GoogleUserInfo to DbUser and store it
+    // Convert IdInfo or UserInfo to OAuth2Account using the active provider name
     static OAUTH2_GOOGLE_USER: &str = "idinfo";
 
     let oauth2_account = match OAUTH2_GOOGLE_USER {
-        "idinfo" => OAuth2Account::from(idinfo),
-        "userinfo" => OAuth2Account::from(userinfo),
-        _ => OAuth2Account::from(idinfo), // Default case
+        "idinfo" => oauth2_account_from_idinfo(&idinfo, provider_name),
+        "userinfo" => oauth2_account_from_userinfo(&userinfo, provider_name),
+        _ => oauth2_account_from_idinfo(&idinfo, provider_name), // Default case
     };
 
     // Decode the state from the auth response
@@ -433,11 +482,16 @@ pub async fn fedcm_authorized_core(
 ) -> Result<(HeaderMap, String), CoordinationError> {
     tracing::info!("Processing FedCM authorization callback");
 
+    // FedCM is currently Google-only.
+    let ctx = provider_for(ProviderKind::Google).ok_or_else(|| {
+        CoordinationError::InvalidState("Google provider not available".to_string())
+    })?;
+
     // 1. Validate ID token and verify nonce (single-use)
-    let idinfo = validate_fedcm_token(&request.credential, &request.nonce_id).await?;
+    let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
 
     // 2. Build OAuth2Account from the verified ID token
-    let oauth2_account = OAuth2Account::from(idinfo);
+    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
 
     // 3. Parse mode directly from request (no cache round-trip needed for FedCM)
     let mode = match &request.mode {
@@ -472,6 +526,48 @@ pub async fn fedcm_authorized_core(
     )
     .await?;
 
+    Ok(result)
+}
+
+/// Test-accessible variant of `fedcm_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
+/// This allows tests to inject mock server URLs without touching `LazyLock`s.
+#[cfg(test)]
+pub(crate) async fn fedcm_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    request: &FedCMCallbackRequest,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
+    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
+
+    let mode = match &request.mode {
+        Some(mode_str) => {
+            let parsed: OAuth2Mode = mode_str.parse().map_err(|_| {
+                CoordinationError::InvalidState(format!("Invalid FedCM mode: {mode_str}"))
+            })?;
+            Some(parsed)
+        }
+        None => None,
+    };
+
+    if matches!(mode, Some(OAuth2Mode::AddToUser)) {
+        return Err(CoordinationError::InvalidState(
+            "FedCM does not support add_to_user mode".to_string(),
+        ));
+    }
+
+    let login_context = LoginContext::from_headers(headers);
+    let result = process_authenticated_oauth2_user(
+        oauth2_account,
+        mode,
+        AuthMethod::FedCM,
+        login_context,
+        None,
+        None,
+        None,
+    )
+    .await?;
     Ok(result)
 }
 

--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -207,31 +207,6 @@ pub async fn post_authorized_core(
     authorized_core(ctx, HttpMethod::Post, auth_response, cookies, headers).await
 }
 
-/// Test-accessible variant of `get_authorized_core` that accepts a pre-built
-/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
-/// This allows tests to inject mock server URLs without touching `LazyLock`s.
-#[cfg(test)]
-pub(crate) async fn get_authorized_core_with_ctx(
-    ctx: &ProviderConfig,
-    auth_response: &AuthResponse,
-    cookies: &headers::Cookie,
-    headers: &HeaderMap,
-) -> Result<(HeaderMap, String), CoordinationError> {
-    authorized_core(ctx, HttpMethod::Get, auth_response, cookies, headers).await
-}
-
-/// Test-accessible variant of `post_authorized_core` that accepts a pre-built
-/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
-#[cfg(test)]
-pub(crate) async fn post_authorized_core_with_ctx(
-    ctx: &ProviderConfig,
-    auth_response: &AuthResponse,
-    cookies: &headers::Cookie,
-    headers: &HeaderMap,
-) -> Result<(HeaderMap, String), CoordinationError> {
-    authorized_core(ctx, HttpMethod::Post, auth_response, cookies, headers).await
-}
-
 #[tracing::instrument(skip(ctx, auth_response, login_context), fields(user_id, provider, state = %auth_response.state))]
 async fn process_oauth2_authorization(
     ctx: &ProviderConfig,
@@ -242,9 +217,27 @@ async fn process_oauth2_authorization(
     tracing::Span::current().record("provider", provider_name);
     tracing::info!("Processing OAuth2 authorization core logic");
 
-    // Upsert oauth2_account and user
-    // 1. Decode the state from the auth response
-    // 2. Extract user_id from the stored session if available
+    // Decode the state from the auth response first so we can cross-check the provider
+    // before doing any expensive token exchange.
+    let oauth2_state = crate::OAuth2State::new(auth_response.state.clone())?;
+    let state_in_response = decode_state(&oauth2_state)?;
+
+    // Defense-in-depth: the URL path provider is the authoritative dispatch signal.
+    // The `provider` field in `StateParams` is a cross-check to detect URL/state
+    // mismatches (e.g. an attacker submitting a Google state to an Auth0 callback).
+    // Reject on mismatch so the flow never reaches the token exchange.
+    if state_in_response.provider != provider_name {
+        tracing::error!(
+            security_event = "provider_mismatch",
+            state_provider = %state_in_response.provider,
+            url_path_provider = %provider_name,
+            "Provider mismatch: state.provider does not match URL path provider"
+        );
+        return Err(CoordinationError::InvalidState(format!(
+            "Provider mismatch: state contains '{}' but URL path is '{}'",
+            state_in_response.provider, provider_name
+        )));
+    }
 
     let (idinfo, userinfo) = get_idinfo_userinfo(ctx, auth_response).await?;
 
@@ -256,10 +249,6 @@ async fn process_oauth2_authorization(
         "userinfo" => oauth2_account_from_userinfo(&userinfo, provider_name),
         _ => oauth2_account_from_idinfo(&idinfo, provider_name), // Default case
     };
-
-    // Decode the state from the auth response
-    let oauth2_state = crate::OAuth2State::new(auth_response.state.clone())?;
-    let state_in_response = decode_state(&oauth2_state)?;
 
     // Extract user_id from the stored session if available
     let state_user = get_uid_from_stored_session_by_state_param(&state_in_response).await?;
@@ -526,48 +515,6 @@ pub async fn fedcm_authorized_core(
     )
     .await?;
 
-    Ok(result)
-}
-
-/// Test-accessible variant of `fedcm_authorized_core` that accepts a pre-built
-/// `ProviderConfig` directly, bypassing the global `GOOGLE_PROVIDER` static.
-/// This allows tests to inject mock server URLs without touching `LazyLock`s.
-#[cfg(test)]
-pub(crate) async fn fedcm_authorized_core_with_ctx(
-    ctx: &ProviderConfig,
-    request: &FedCMCallbackRequest,
-    headers: &HeaderMap,
-) -> Result<(HeaderMap, String), CoordinationError> {
-    let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
-    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
-
-    let mode = match &request.mode {
-        Some(mode_str) => {
-            let parsed: OAuth2Mode = mode_str.parse().map_err(|_| {
-                CoordinationError::InvalidState(format!("Invalid FedCM mode: {mode_str}"))
-            })?;
-            Some(parsed)
-        }
-        None => None,
-    };
-
-    if matches!(mode, Some(OAuth2Mode::AddToUser)) {
-        return Err(CoordinationError::InvalidState(
-            "FedCM does not support add_to_user mode".to_string(),
-        ));
-    }
-
-    let login_context = LoginContext::from_headers(headers);
-    let result = process_authenticated_oauth2_user(
-        oauth2_account,
-        mode,
-        AuthMethod::FedCM,
-        login_context,
-        None,
-        None,
-        None,
-    )
-    .await?;
     Ok(result)
 }
 

--- a/oauth2_passkey/src/coordination/oauth2/tests.rs
+++ b/oauth2_passkey/src/coordination/oauth2/tests.rs
@@ -1,5 +1,9 @@
 use super::*;
-use crate::oauth2::{FedCMCallbackRequest, OAuth2Account, OAuth2Error, prepare_fedcm_nonce};
+use crate::oauth2::provider::ProviderConfig;
+use crate::oauth2::{
+    FedCMCallbackRequest, OAuth2Account, OAuth2Error, prepare_fedcm_nonce,
+    prepare_oauth2_auth_request_inner,
+};
 use crate::test_utils::init_test_environment;
 use crate::userdb::User;
 use chrono::Utc;
@@ -275,7 +279,7 @@ impl Default for MockServerState {
         Self {
             auth_codes: Arc::new(StdMutex::new(HashMap::new())),
             user_email: Arc::new(StdMutex::new("first-user@example.com".to_string())),
-            // Note: From<IdInfo> adds "google_" prefix to sub, so sub should NOT include it.
+            // Note: oauth2_account_from_idinfo adds "google_" prefix to sub, so sub should NOT include it.
             // "first-user-test-google-id" -> provider_user_id = "google_first-user-test-google-id"
             user_sub: Arc::new(StdMutex::new("first-user-test-google-id".to_string())),
             user_name: Arc::new(StdMutex::new("First User".to_string())),
@@ -555,8 +559,9 @@ async fn drive_oauth2_flow(
         }
     }
 
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
     let (auth_url, response_headers) =
-        crate::oauth2::prepare_oauth2_auth_request(request_headers, Some(mode)).await?;
+        prepare_oauth2_auth_request_inner(&ctx, request_headers, Some(mode)).await?;
 
     // 2. Extract CSRF cookie value from Set-Cookie header
     let set_cookie = response_headers
@@ -644,7 +649,10 @@ async fn test_post_authorized_core_wrong_response_mode() -> Result<(), Box<dyn s
     cookie_hmap.insert(http::header::COOKIE, "dummy=value".parse().unwrap());
     let cookie: headers::Cookie = cookie_hmap.typed_get().expect("Should parse Cookie header");
 
-    let result = post_authorized_core(&auth_response, &cookie, &http::HeaderMap::new()).await;
+    // for_mock_server uses response_mode="query", so POST should be rejected
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result =
+        post_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &http::HeaderMap::new()).await;
 
     assert!(
         matches!(result, Err(CoordinationError::InvalidResponseMode(_))),
@@ -668,7 +676,8 @@ async fn test_get_authorized_core_login_existing_user() -> Result<(), Box<dyn st
     mock.reset_to_first_user();
 
     let (auth_response, cookie, headers) = drive_oauth2_flow("login", None).await?;
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
 
     assert!(
         result.is_ok(),
@@ -702,7 +711,7 @@ async fn test_get_authorized_core_login_nonexistent_account()
     set_mock_env_vars();
 
     // Configure mock with a user that has no existing account in the database.
-    // Note: sub should NOT include "google_" prefix (From<IdInfo> adds it).
+    // Note: sub should NOT include "google_" prefix (oauth2_account_from_idinfo adds it).
     // Guard resets to first user on drop (panic-safe).
     let _guard = mock.configure_user_guarded(
         "nonexistent@example.com",
@@ -711,7 +720,8 @@ async fn test_get_authorized_core_login_nonexistent_account()
     );
 
     let (auth_response, cookie, headers) = drive_oauth2_flow("login", None).await?;
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
 
     assert!(
         matches!(result, Err(CoordinationError::Conflict(_))),
@@ -733,7 +743,7 @@ async fn test_get_authorized_core_create_new_user() -> Result<(), Box<dyn std::e
     set_mock_env_vars();
 
     // Configure mock with a new user identity.
-    // Note: sub should NOT include "google_" prefix (From<IdInfo> adds it).
+    // Note: sub should NOT include "google_" prefix (oauth2_account_from_idinfo adds it).
     // Guard resets to first user on drop (panic-safe).
     let timestamp = chrono::Utc::now().timestamp_millis();
     let new_email = format!("new-user-{timestamp}@example.com");
@@ -742,7 +752,8 @@ async fn test_get_authorized_core_create_new_user() -> Result<(), Box<dyn std::e
     let _guard = mock.configure_user_guarded(&new_email, &new_sub, &new_name);
 
     let (auth_response, cookie, headers) = drive_oauth2_flow("create_user", None).await?;
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
 
     assert!(
         result.is_ok(),
@@ -760,7 +771,7 @@ async fn test_get_authorized_core_create_new_user() -> Result<(), Box<dyn std::e
     );
 
     // Verify the OAuth2 account was created in the database
-    // From<IdInfo> adds "google_" prefix to sub -> provider_user_id
+    // oauth2_account_from_idinfo adds "google_" prefix to sub -> provider_user_id
     let expected_provider_user_id = format!("google_{new_sub}");
     let provider = crate::oauth2::Provider::new("google".to_string()).unwrap();
     let provider_user_id = crate::oauth2::ProviderUserId::new(expected_provider_user_id).unwrap();
@@ -788,7 +799,7 @@ async fn test_get_authorized_core_create_user_or_login() -> Result<(), Box<dyn s
     set_mock_env_vars();
 
     // Part 1: Create user (new OAuth2 identity).
-    // Note: sub should NOT include "google_" prefix (From<IdInfo> adds it).
+    // Note: sub should NOT include "google_" prefix (oauth2_account_from_idinfo adds it).
     // Guard resets to first user on drop (panic-safe).
     let timestamp = chrono::Utc::now().timestamp_millis();
     let new_email = format!("dual-mode-{timestamp}@example.com");
@@ -797,7 +808,8 @@ async fn test_get_authorized_core_create_user_or_login() -> Result<(), Box<dyn s
     let _guard = mock.configure_user_guarded(&new_email, &new_sub, &new_name);
 
     let (auth_response, cookie, headers) = drive_oauth2_flow("create_user_or_login", None).await?;
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
     assert!(
         result.is_ok(),
         "create_user_or_login with new identity should succeed: {result:?}"
@@ -810,7 +822,8 @@ async fn test_get_authorized_core_create_user_or_login() -> Result<(), Box<dyn s
 
     // Part 2: Login (same OAuth2 identity, now exists)
     let (auth_response, cookie, headers) = drive_oauth2_flow("create_user_or_login", None).await?;
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
     assert!(
         result.is_ok(),
         "create_user_or_login with existing identity should succeed: {result:?}"
@@ -854,7 +867,7 @@ async fn test_get_authorized_core_add_to_user() -> Result<(), Box<dyn std::error
     session_request_headers.insert(http::header::COOKIE, session_cookie_pair.parse()?);
 
     // Configure mock with a NEW OAuth2 identity to link.
-    // Note: sub should NOT include "google_" prefix (From<IdInfo> adds it).
+    // Note: sub should NOT include "google_" prefix (oauth2_account_from_idinfo adds it).
     // Guard resets to first user on drop (panic-safe).
     let timestamp = chrono::Utc::now().timestamp_millis();
     let link_email = format!("linked-{timestamp}@example.com");
@@ -867,7 +880,8 @@ async fn test_get_authorized_core_add_to_user() -> Result<(), Box<dyn std::error
         drive_oauth2_flow("add_to_user", Some(&session_request_headers)).await?;
 
     // Step 3: Call get_authorized_core
-    let result = get_authorized_core(&auth_response, &cookie, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = get_authorized_core_with_ctx(&ctx, &auth_response, &cookie, &headers).await;
     assert!(result.is_ok(), "add_to_user should succeed: {result:?}");
     let (_response_headers, message) = result.unwrap();
     assert!(
@@ -876,7 +890,7 @@ async fn test_get_authorized_core_add_to_user() -> Result<(), Box<dyn std::error
     );
 
     // Verify the new OAuth2 account is linked to the first user
-    // From<IdInfo> adds "google_" prefix to sub -> provider_user_id
+    // oauth2_account_from_idinfo adds "google_" prefix to sub -> provider_user_id
     let expected_provider_user_id = format!("google_{link_sub}");
     let provider = crate::oauth2::Provider::new("google".to_string()).unwrap();
     let provider_user_id = crate::oauth2::ProviderUserId::new(expected_provider_user_id).unwrap();
@@ -928,8 +942,9 @@ async fn drive_fedcm_flow(
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    // 6. Call fedcm_authorized_core
-    let result = fedcm_authorized_core(&request, &headers).await?;
+    // 6. Call fedcm_authorized_core_with_ctx using mock server config
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await?;
     Ok(result)
 }
 
@@ -971,7 +986,7 @@ async fn test_fedcm_login_nonexistent_account() -> Result<(), Box<dyn std::error
     set_mock_env_vars();
 
     // Configure mock with a user that has no existing account in the database.
-    // Note: sub should NOT include "google_" prefix (From<IdInfo> adds it).
+    // Note: sub should NOT include "google_" prefix (oauth2_account_from_idinfo adds it).
     let _guard = mock.configure_user_guarded(
         "fedcm-nonexistent@example.com",
         "fedcm-nonexistent-id",
@@ -994,7 +1009,8 @@ async fn test_fedcm_login_nonexistent_account() -> Result<(), Box<dyn std::error
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         matches!(result, Err(CoordinationError::Conflict(_))),
         "FedCM login with nonexistent account should return Conflict error, got: {result:?}"
@@ -1107,7 +1123,8 @@ async fn test_fedcm_reject_add_to_user() -> Result<(), Box<dyn std::error::Error
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         matches!(result, Err(CoordinationError::InvalidState(_))),
         "FedCM should reject add_to_user mode, got: {result:?}"
@@ -1146,7 +1163,8 @@ async fn test_fedcm_create_existing_user_conflict() -> Result<(), Box<dyn std::e
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         matches!(result, Err(CoordinationError::Conflict(_))),
         "FedCM create_user with existing account should return Conflict, got: {result:?}"
@@ -1184,7 +1202,8 @@ async fn test_fedcm_nonce_replay() -> Result<(), Box<dyn std::error::Error>> {
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let first_result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let first_result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         first_result.is_ok(),
         "First FedCM call should succeed: {first_result:?}"
@@ -1196,7 +1215,7 @@ async fn test_fedcm_nonce_replay() -> Result<(), Box<dyn std::error::Error>> {
         nonce_id: nonce_response.nonce_id,
         mode: Some("login".to_string()),
     };
-    let replay_result = fedcm_authorized_core(&replay_request, &headers).await;
+    let replay_result = fedcm_authorized_core_with_ctx(&ctx, &replay_request, &headers).await;
     assert!(
         matches!(
             replay_result,
@@ -1238,7 +1257,8 @@ async fn test_fedcm_nonce_mismatch() -> Result<(), Box<dyn std::error::Error>> {
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         matches!(
             result,
@@ -1279,7 +1299,8 @@ async fn test_fedcm_mode_none() -> Result<(), Box<dyn std::error::Error>> {
     let mut headers = http::HeaderMap::new();
     headers.insert(http::header::USER_AGENT, "TestBrowser/1.0".parse().unwrap());
 
-    let result = fedcm_authorized_core(&request, &headers).await;
+    let ctx = ProviderConfig::for_mock_server(MOCK_BASE_URL);
+    let result = fedcm_authorized_core_with_ctx(&ctx, &request, &headers).await;
     assert!(
         matches!(result, Err(CoordinationError::InvalidState(_))),
         "FedCM with mode=None should return InvalidState, got: {result:?}"

--- a/oauth2_passkey/src/coordination/oauth2/tests.rs
+++ b/oauth2_passkey/src/coordination/oauth2/tests.rs
@@ -9,6 +9,69 @@ use crate::userdb::User;
 use chrono::Utc;
 use serial_test::serial;
 
+/// Test-accessible variant of `get_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global provider static.
+/// This allows tests to inject mock server URLs without touching `LazyLock`s.
+async fn get_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    auth_response: &AuthResponse,
+    cookies: &headers::Cookie,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    authorized_core(ctx, HttpMethod::Get, auth_response, cookies, headers).await
+}
+
+/// Test-accessible variant of `post_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global provider static.
+async fn post_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    auth_response: &AuthResponse,
+    cookies: &headers::Cookie,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    authorized_core(ctx, HttpMethod::Post, auth_response, cookies, headers).await
+}
+
+/// Test-accessible variant of `fedcm_authorized_core` that accepts a pre-built
+/// `ProviderConfig` directly, bypassing the global provider static.
+async fn fedcm_authorized_core_with_ctx(
+    ctx: &ProviderConfig,
+    request: &FedCMCallbackRequest,
+    headers: &HeaderMap,
+) -> Result<(HeaderMap, String), CoordinationError> {
+    let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
+    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
+
+    let mode = match &request.mode {
+        Some(mode_str) => {
+            let parsed: OAuth2Mode = mode_str.parse().map_err(|_| {
+                CoordinationError::InvalidState(format!("Invalid FedCM mode: {mode_str}"))
+            })?;
+            Some(parsed)
+        }
+        None => None,
+    };
+
+    if matches!(mode, Some(OAuth2Mode::AddToUser)) {
+        return Err(CoordinationError::InvalidState(
+            "FedCM does not support add_to_user mode".to_string(),
+        ));
+    }
+
+    let login_context = LoginContext::from_headers(headers);
+    let result = process_authenticated_oauth2_user(
+        oauth2_account,
+        mode,
+        AuthMethod::FedCM,
+        login_context,
+        None,
+        None,
+        None,
+    )
+    .await?;
+    Ok(result)
+}
+
 // Additional imports for mock OAuth2 server tests
 use axum::routing::{get, post};
 use headers::HeaderMapExt;

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -1,162 +1,25 @@
-use super::discovery::{OidcDiscoveryDocument, OidcDiscoveryError, fetch_oidc_discovery};
-use crate::config::O2P_ROUTE_PREFIX;
-use std::{
-    env,
-    sync::{LazyLock, OnceLock},
-};
+use std::sync::LazyLock;
 
-/// Base issuer URL for OIDC discovery
-/// Set this to enable automatic discovery of OAuth2 endpoints
-pub(crate) static OAUTH2_ISSUER_URL: LazyLock<String> = LazyLock::new(|| {
-    env::var("OAUTH2_ISSUER_URL")
-        .ok()
-        .unwrap_or("https://accounts.google.com".to_string())
-});
+// "__Host-" prefix forces host-only cookies (no Domain attribute, Secure flag required).
 
-/// Cache for discovered OIDC endpoints
-/// This is populated on first use and cached for the lifetime of the application
-static OIDC_DISCOVERY_CACHE: OnceLock<OidcDiscoveryDocument> = OnceLock::new();
-
-/// Get discovered OIDC endpoints, fetching from the issuer's well-known endpoint if not cached
-pub(crate) async fn get_discovered_endpoints()
--> Result<&'static OidcDiscoveryDocument, OidcDiscoveryError> {
-    // Return cached version if available
-    if let Some(cached) = OIDC_DISCOVERY_CACHE.get() {
-        return Ok(cached);
-    }
-
-    // Fetch discovery document
-    tracing::debug!("Fetching OIDC discovery for issuer: {}", *OAUTH2_ISSUER_URL);
-    let document = fetch_oidc_discovery(&OAUTH2_ISSUER_URL).await?;
-
-    // Store in cache (first write wins in case of concurrent access)
-    let _ = OIDC_DISCOVERY_CACHE.set(document);
-
-    // Return the cached version - this should always succeed since either we just set it
-    // or another thread set it between our check and now
-    OIDC_DISCOVERY_CACHE.get().ok_or_else(|| {
-        OidcDiscoveryError::CacheError("Failed to cache discovery document".to_string())
-    })
-}
-
-/// Get authorization URL, using discovery if no environment override is set
-pub(crate) async fn get_auth_url() -> Result<String, OidcDiscoveryError> {
-    // Check for environment variable override first
-    if let Ok(env_url) = env::var("OAUTH2_AUTH_URL") {
-        tracing::debug!("Using OAUTH2_AUTH_URL from environment: {}", env_url);
-        return Ok(env_url);
-    }
-
-    // Use discovery
-    let endpoints = get_discovered_endpoints().await?;
-    tracing::debug!(
-        "Using authorization endpoint from discovery: {}",
-        endpoints.authorization_endpoint
-    );
-    Ok(endpoints.authorization_endpoint.clone())
-}
-
-/// Get token URL, using discovery if no environment override is set
-pub(crate) async fn get_token_url() -> Result<String, OidcDiscoveryError> {
-    // Check for environment variable override first
-    if let Ok(env_url) = env::var("OAUTH2_TOKEN_URL") {
-        tracing::debug!("Using OAUTH2_TOKEN_URL from environment: {}", env_url);
-        return Ok(env_url);
-    }
-
-    // Use discovery
-    let endpoints = get_discovered_endpoints().await?;
-    tracing::debug!(
-        "Using token endpoint from discovery: {}",
-        endpoints.token_endpoint
-    );
-    Ok(endpoints.token_endpoint.clone())
-}
-
-/// Get userinfo URL, using discovery if no environment override is set
-pub(crate) async fn get_userinfo_url() -> Result<String, OidcDiscoveryError> {
-    // Check for environment variable override first
-    if let Ok(env_url) = env::var("OAUTH2_USERINFO_URL") {
-        tracing::debug!("Using OAUTH2_USERINFO_URL from environment: {}", env_url);
-        return Ok(env_url);
-    }
-
-    // Use discovery
-    let endpoints = get_discovered_endpoints().await?;
-    tracing::debug!(
-        "Using userinfo endpoint from discovery: {}",
-        endpoints.userinfo_endpoint
-    );
-    Ok(endpoints.userinfo_endpoint.clone())
-}
-
-/// Get JWKS URL, using discovery if no environment override is set
-pub(crate) async fn get_jwks_url() -> Result<String, OidcDiscoveryError> {
-    // Check for environment variable override first
-    if let Ok(env_url) = env::var("OAUTH2_JWKS_URL") {
-        tracing::debug!("Using OAUTH2_JWKS_URL from environment: {}", env_url);
-        return Ok(env_url);
-    }
-
-    // Use discovery
-    let endpoints = get_discovered_endpoints().await?;
-    tracing::debug!("Using JWKS URI from discovery: {}", endpoints.jwks_uri);
-    Ok(endpoints.jwks_uri.clone())
-}
-
-/// Get expected issuer, using discovery if no environment override is set
-pub(crate) async fn get_expected_issuer() -> Result<String, OidcDiscoveryError> {
-    // Check for environment variable override first
-    if let Ok(env_issuer) = env::var("OAUTH2_EXPECTED_ISSUER") {
-        tracing::debug!(
-            "Using OAUTH2_EXPECTED_ISSUER from environment: {}",
-            env_issuer
-        );
-        return Ok(env_issuer);
-    }
-
-    // Use discovery
-    let endpoints = get_discovered_endpoints().await?;
-    tracing::debug!("Using issuer from discovery: {}", endpoints.issuer);
-    Ok(endpoints.issuer.clone())
-}
-
-static OAUTH2_SCOPE: LazyLock<String> =
-    LazyLock::new(|| std::env::var("OAUTH2_SCOPE").unwrap_or("openid+email+profile".to_string()));
-
-pub(crate) static OAUTH2_RESPONSE_MODE: LazyLock<String> = LazyLock::new(|| {
-    let mode = std::env::var("OAUTH2_RESPONSE_MODE").unwrap_or("form_post".to_string());
-    match mode.to_lowercase().as_str() {
-        "form_post" => "form_post".to_string(),
-        "query" => "query".to_string(),
-        _ => {
-            panic!("Invalid OAUTH2_RESPONSE_MODE '{mode}'. Must be 'form_post' or 'query'.");
-        }
-    }
-});
-
-static OAUTH2_RESPONSE_TYPE: LazyLock<String> =
-    LazyLock::new(|| std::env::var("OAUTH2_RESPONSE_TYPE").unwrap_or("code".to_string()));
-
-pub(crate) static OAUTH2_QUERY_STRING: LazyLock<String> = LazyLock::new(|| {
-    let mut query_string = "".to_string();
-    query_string.push_str(&format!("&response_type={}", *OAUTH2_RESPONSE_TYPE));
-    query_string.push_str(&format!("&scope={}", *OAUTH2_SCOPE));
-    query_string.push_str(&format!("&response_mode={}", *OAUTH2_RESPONSE_MODE));
-    query_string.push_str(&format!("&access_type={}", "online"));
-    query_string.push_str(&format!("&prompt={}", "consent"));
-    query_string
-});
-
-// Supported parameters:
-// response_type: code
-// scope: openid+email+profile
-// response_mode: form_post, query
-// access_type: online, offline(for refresh token)
-// prompt: none, consent, select_account
-
-// "__Host-" prefix are added to make cookies "host-only".
-
+/// CSRF cookie name used for the OAuth2 flow CSRF protection.
+///
+/// This is intentionally a **single global** name, not per-provider.
+/// It implements the "latest OAuth2 flow wins" policy: when a new flow
+/// starts while another is in flight, the new flow's cookie overwrites
+/// the old one.  The abandoned flow's callback then fails `csrf_checks`
+/// because the cookie token no longer matches the cached token for that
+/// flow's `csrf_id`.
+///
+/// This is a deliberate security decision: OAuth2 callbacks have
+/// irreversible side effects (session rotation, account linking, login
+/// history), so silently completing an abandoned parallel flow would
+/// create unintended state.  Fail-closed is the correct direction.
+///
+/// Do NOT make this per-provider.  If a future PR proposes per-instance
+/// cookie naming, it must first justify changing this policy.
+/// See Decision Log entry "2026-04-16: Preserve the 'latest flow wins'
+/// CSRF cookie policy" in issue `20260226-2020`.
 pub(crate) static OAUTH2_CSRF_COOKIE_NAME: LazyLock<String> = LazyLock::new(|| {
     std::env::var("OAUTH2_CSRF_COOKIE_NAME")
         .ok()
@@ -171,26 +34,14 @@ pub(super) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> =
         Err(_) => 60,
     });
 
-pub(super) static OAUTH2_REDIRECT_URI: LazyLock<String> = LazyLock::new(|| {
-    format!(
-        "{}{}/oauth2/authorized",
-        env::var("ORIGIN").expect("Missing ORIGIN!"),
-        O2P_ROUTE_PREFIX.as_str()
-    )
-});
-
-pub(super) static OAUTH2_GOOGLE_CLIENT_ID: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("OAUTH2_GOOGLE_CLIENT_ID").expect("OAUTH2_GOOGLE_CLIENT_ID must be set")
-});
-
-/// Get the OAuth2 Google Client ID (needed by FedCM to embed in frontend)
+/// Get the Google OAuth2 client ID.
+///
+/// Used by FedCM to embed the client ID in the frontend JavaScript.
+/// Delegates to `GOOGLE_PROVIDER.client_id` so the value is always
+/// consistent with the running provider configuration.
 pub fn get_google_client_id() -> &'static str {
-    OAUTH2_GOOGLE_CLIENT_ID.as_str()
+    &crate::oauth2::provider::GOOGLE_PROVIDER.client_id
 }
-
-pub(super) static OAUTH2_GOOGLE_CLIENT_SECRET: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("OAUTH2_GOOGLE_CLIENT_SECRET").expect("OAUTH2_GOOGLE_CLIENT_SECRET must be set")
-});
 
 #[cfg(test)]
 mod tests;

--- a/oauth2_passkey/src/oauth2/config/tests.rs
+++ b/oauth2_passkey/src/oauth2/config/tests.rs
@@ -1,6 +1,35 @@
 use super::*;
 use crate::test_utils::{run_child_with_env as run_child, run_child_without_env};
 
+// --- OAUTH2_CSRF_COOKIE_NAME ---
+
+#[test]
+fn test_oauth2_csrf_cookie_name_defaults_to_host_prefix() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        assert_eq!(OAUTH2_CSRF_COOKIE_NAME.as_str(), "__Host-CsrfId");
+        return;
+    }
+    let output = run_child_without_env(
+        "oauth2::config::tests::test_oauth2_csrf_cookie_name_defaults_to_host_prefix",
+        "OAUTH2_CSRF_COOKIE_NAME",
+    );
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_oauth2_csrf_cookie_name_accepts_custom_value() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        assert_eq!(OAUTH2_CSRF_COOKIE_NAME.as_str(), "MyCsrfCookie");
+        return;
+    }
+    let output = run_child(
+        "oauth2::config::tests::test_oauth2_csrf_cookie_name_accepts_custom_value",
+        "OAUTH2_CSRF_COOKIE_NAME",
+        "MyCsrfCookie",
+    );
+    assert!(output.status.success());
+}
+
 // --- OAUTH2_CSRF_COOKIE_MAX_AGE ---
 
 #[test]

--- a/oauth2_passkey/src/oauth2/discovery.rs
+++ b/oauth2_passkey/src/oauth2/discovery.rs
@@ -79,9 +79,11 @@ pub(crate) async fn fetch_oidc_discovery(
 
     let document: OidcDiscoveryDocument = response.json().await?;
 
-    // Validate that the issuer in the document matches the expected issuer
-    // This is a security requirement per OIDC specification
-    if document.issuer != issuer_url {
+    // Validate that the issuer in the document matches the expected issuer.
+    // This is a security requirement per OIDC specification.
+    // Normalise both sides: some providers (e.g. Auth0) return a trailing
+    // slash in their issuer field even though the discovery URL had none.
+    if document.issuer.trim_end_matches('/') != issuer_url {
         tracing::error!(
             "Issuer mismatch in discovery document. Expected: {}, Found: {}",
             issuer_url,

--- a/oauth2_passkey/src/oauth2/main/core.rs
+++ b/oauth2_passkey/src/oauth2/main/core.rs
@@ -5,17 +5,15 @@ use chrono::{Duration, Utc};
 use jsonwebtoken::Algorithm;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-use crate::oauth2::config::{
-    OAUTH2_CSRF_COOKIE_MAX_AGE, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_GOOGLE_CLIENT_ID,
-    OAUTH2_QUERY_STRING, OAUTH2_REDIRECT_URI, OAUTH2_RESPONSE_MODE, get_auth_url,
-};
+use crate::oauth2::config::{OAUTH2_CSRF_COOKIE_MAX_AGE, OAUTH2_CSRF_COOKIE_NAME};
 use crate::oauth2::errors::OAuth2Error;
-use crate::oauth2::types::{AuthResponse, GoogleUserInfo, StateParams, StoredToken, TokenType};
+use crate::oauth2::provider::{ProviderConfig, ProviderKind, provider_for};
+use crate::oauth2::types::{AuthResponse, OidcUserInfo, StateParams, StoredToken, TokenType};
 use crate::session::get_session_id_from_headers;
 use crate::utils::base64url_encode;
 
-use super::google::{exchange_code_for_token, fetch_user_data_from_google};
-use super::idtoken::{IdInfo as GoogleIdInfo, verify_idtoken_with_algorithm};
+use super::idtoken::{OidcIdInfo, verify_idtoken_with_algorithm};
+use super::oidc::{exchange_code_for_token, fetch_userinfo};
 use super::utils::{decode_state, encode_state, generate_store_token, verify_and_consume_nonce};
 use crate::storage::{
     CacheErrorConversion, CacheKey, CachePrefix, get_data, remove_data, store_cache_auto,
@@ -23,19 +21,19 @@ use crate::storage::{
 
 /// Prepares an OAuth2 authentication request URL and necessary headers.
 ///
-/// This function generates a secure OAuth2 authorization URL for redirecting users
-/// to the identity provider (e.g., Google). It also sets up CSRF protection by
-/// generating and storing a state parameter.
+/// Resolves the provider configuration from `provider` (URL path segment),
+/// then builds the authorization URL and sets the CSRF cookie.
 ///
 /// # Arguments
 ///
-/// * `headers` - HTTP headers from the client request, used to extract user agent and other info
-/// * `mode` - Optional authentication mode (e.g., "login", "create_user", etc.)
+/// * `provider` - Provider identifier from the URL path (e.g. "google")
+/// * `headers` - HTTP headers from the client request
+/// * `mode` - Optional authentication mode (e.g. "login", "create_user")
 ///
 /// # Returns
 ///
 /// * `Ok((String, HeaderMap))` - The authorization URL and response headers
-/// * `Err(OAuth2Error)` - If an error occurs during preparation
+/// * `Err(OAuth2Error)` - If the provider is unknown or an error occurs
 ///
 /// # Examples
 ///
@@ -44,32 +42,35 @@ use crate::storage::{
 /// use http::HeaderMap;
 ///
 /// async fn start_oauth_flow(request_headers: HeaderMap) -> Result<(String, HeaderMap), Box<dyn std::error::Error>> {
-///     let (auth_url, response_headers) = prepare_oauth2_auth_request(request_headers, Some("login")).await?;
+///     let (auth_url, response_headers) = prepare_oauth2_auth_request("google", request_headers, Some("login")).await?;
 ///     Ok((auth_url, response_headers))
 /// }
 /// ```
 pub async fn prepare_oauth2_auth_request(
+    provider: &str,
     headers: HeaderMap,
     mode: Option<&str>,
 ) -> Result<(String, HeaderMap), OAuth2Error> {
-    // Resolve configuration values
-    let auth_base_url = get_auth_url().await?;
-    let response_mode = OAUTH2_RESPONSE_MODE.as_str();
-
-    // Delegate to the internal function that builds the request
-    prepare_oauth2_auth_request_with_params(headers, mode, &auth_base_url, response_mode).await
+    let kind = ProviderKind::from_path_segment(provider)
+        .ok_or_else(|| OAuth2Error::Validation(format!("Unknown provider: {provider}")))?;
+    let ctx = provider_for(kind)
+        .ok_or_else(|| OAuth2Error::Validation(format!("Provider not enabled: {provider}")))?;
+    prepare_oauth2_auth_request_inner(ctx, headers, mode).await
 }
 
-/// Internal function that builds OAuth2 authorization request with provided parameters
+/// Internal function that builds the OAuth2 authorization request.
 ///
-/// This separation allows for comprehensive testing by injecting both auth URL and response mode,
-/// enabling unit tests to validate cookie security attributes for all response modes.
-async fn prepare_oauth2_auth_request_with_params(
+/// Separated from the public entry point so tests can inject a `ProviderConfig`
+/// constructed directly (without touching `LazyLock` globals or env vars).
+pub(crate) async fn prepare_oauth2_auth_request_inner(
+    ctx: &ProviderConfig,
     headers: HeaderMap,
     mode: Option<&str>,
-    auth_base_url: &str,
-    response_mode: &str,
 ) -> Result<(String, HeaderMap), OAuth2Error> {
+    let auth_base_url = ctx.auth_url().await?;
+    let response_mode = ctx.response_mode.as_str();
+    let provider_name = ctx.kind.as_str();
+
     let expires_at = Utc::now() + Duration::seconds((*OAUTH2_CSRF_COOKIE_MAX_AGE) as i64);
     let ttl = *OAUTH2_CSRF_COOKIE_MAX_AGE;
     let user_agent = headers
@@ -133,6 +134,7 @@ async fn prepare_oauth2_auth_request_with_params(
         pkce_id,
         misc_id,
         mode_id,
+        provider: provider_name.to_string(),
     };
 
     let encoded_state = encode_state(state_params)?;
@@ -141,9 +143,9 @@ async fn prepare_oauth2_auth_request_with_params(
         "{}?{}&client_id={}&redirect_uri={}&state={}&nonce={}\
         &code_challenge={}&code_challenge_method={}",
         auth_base_url,
-        OAUTH2_QUERY_STRING.as_str(),
-        OAUTH2_GOOGLE_CLIENT_ID.as_str(),
-        OAUTH2_REDIRECT_URI.as_str(),
+        ctx.query_string.as_str(),
+        ctx.client_id.as_str(),
+        ctx.redirect_uri.as_str(),
         encoded_state,
         nonce_token,
         pkce_challenge,
@@ -154,13 +156,13 @@ async fn prepare_oauth2_auth_request_with_params(
 
     let mut response_headers = HeaderMap::new();
 
-    // Set SameSite attribute based on response mode
-    // form_post requires SameSite=None because it's a cross-site POST
-    // query (redirect) can use SameSite=Lax for better security
+    // Set SameSite attribute based on response mode.
+    // form_post requires SameSite=None because it's a cross-site POST.
+    // query (redirect) can use SameSite=Lax for better security.
     let samesite = match response_mode.to_lowercase().as_str() {
         "form_post" => "None",
         "query" => "Lax",
-        _ => "Lax", // Default to Lax for unknown response modes
+        _ => "Lax",
     };
 
     let cookie = format!(
@@ -181,26 +183,26 @@ async fn prepare_oauth2_auth_request_with_params(
 }
 
 pub(crate) async fn get_idinfo_userinfo(
+    ctx: &ProviderConfig,
     auth_response: &AuthResponse,
-) -> Result<(GoogleIdInfo, GoogleUserInfo), OAuth2Error> {
+) -> Result<(OidcIdInfo, OidcUserInfo), OAuth2Error> {
     let pkce_verifier = get_pkce_verifier(auth_response).await?;
     let (access_token, id_token) =
-        exchange_code_for_token(auth_response.code.clone(), pkce_verifier).await?;
+        exchange_code_for_token(ctx, auth_response.code.clone(), pkce_verifier).await?;
 
-    let (idinfo, algorithm) =
-        verify_idtoken_with_algorithm(id_token, OAUTH2_GOOGLE_CLIENT_ID.to_string())
-            .await
-            .map_err(|e| OAuth2Error::IdToken(e.to_string()))?;
+    let (idinfo, algorithm) = verify_idtoken_with_algorithm(ctx, id_token)
+        .await
+        .map_err(|e| OAuth2Error::IdToken(e.to_string()))?;
 
     verify_at_hash(&idinfo, &access_token, algorithm)?;
 
     verify_nonce(auth_response, idinfo.clone()).await?;
 
-    let userinfo = fetch_user_data_from_google(access_token).await?;
+    let userinfo = fetch_userinfo(ctx, access_token).await?;
 
     if idinfo.sub != userinfo.sub {
         tracing::error!(
-            "Id mismatch in IdInfo and Userinfo: \nIdInfo: {:#?}\nUserInfo: {:#?}",
+            "Id mismatch in OidcIdInfo and Userinfo: \nOidcIdInfo: {:#?}\nUserInfo: {:#?}",
             idinfo,
             userinfo
         );
@@ -227,16 +229,21 @@ async fn get_pkce_verifier(auth_response: &AuthResponse) -> Result<String, OAuth
     Ok(pkce_session.token)
 }
 
-async fn verify_nonce(
-    auth_response: &AuthResponse,
-    idinfo: GoogleIdInfo,
-) -> Result<(), OAuth2Error> {
+async fn verify_nonce(auth_response: &AuthResponse, idinfo: OidcIdInfo) -> Result<(), OAuth2Error> {
     let oauth2_state = crate::OAuth2State::new(auth_response.state.clone())?;
     let state_in_response = decode_state(&oauth2_state)?;
 
     verify_and_consume_nonce(&state_in_response.nonce_id, idinfo.nonce.as_deref()).await
 }
 
+/// CSRF checks for the OAuth2 callback.
+///
+/// The cookie name `OAUTH2_CSRF_COOKIE_NAME` is intentionally a single global
+/// (not per-provider).  This implements the "latest OAuth2 flow wins" policy:
+/// starting a new flow overwrites the cookie, causing any abandoned in-flight
+/// flow's callback to fail here.  See the policy comment in `config.rs` and
+/// the Decision Log entry "2026-04-16: Preserve the 'latest flow wins' CSRF
+/// cookie policy" in issue `20260226-2020` for the full rationale.
 pub(crate) async fn csrf_checks(
     cookies: Cookie,
     query: &AuthResponse,
@@ -344,7 +351,7 @@ fn calculate_at_hash(access_token: &str, algorithm: Algorithm) -> Result<String,
 /// * `Ok(())` - If verification succeeds or at_hash is not present
 /// * `Err(OAuth2Error)` - If verification fails or calculation error occurs
 fn verify_at_hash(
-    idinfo: &GoogleIdInfo,
+    idinfo: &OidcIdInfo,
     access_token: &str,
     algorithm: Algorithm,
 ) -> Result<(), OAuth2Error> {

--- a/oauth2_passkey/src/oauth2/main/core/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/core/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::oauth2::provider::ProviderConfig;
 use crate::test_utils::init_test_environment;
 use std::collections::HashMap;
 
@@ -21,30 +22,20 @@ async fn test_oauth2_request_preparation_with_session() {
         http::HeaderValue::from_static("session_id=test_session_123"),
     );
 
-    // Use the internal function with a test auth URL to avoid external dependencies
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let current_response_mode = OAUTH2_RESPONSE_MODE.as_str();
-    let result = prepare_oauth2_auth_request_with_params(
-        headers,
-        Some("signup"),
-        test_auth_url,
-        current_response_mode,
-    )
-    .await;
+    let ctx = ProviderConfig::for_test(test_auth_url, "query");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, Some("signup")).await;
 
     assert!(result.is_ok());
     let (auth_url, response_headers) = result.unwrap();
 
-    // Test the actual behavior, not implementation details
     let parsed_url = url::Url::parse(&auth_url).expect("Should generate valid URL");
 
-    // Test that auth URL starts with our test URL
     assert!(
         auth_url.starts_with(test_auth_url),
         "Should use provided auth URL"
     );
 
-    // Test OAuth2 parameters are present
     let params: HashMap<String, String> = parsed_url.query_pairs().into_owned().collect();
     assert!(params.contains_key("client_id"), "Should include client_id");
     assert!(
@@ -74,7 +65,6 @@ async fn test_oauth2_request_preparation_with_session() {
         "Should use authorization code flow"
     );
 
-    // Verify CSRF cookie is set in response headers
     let set_cookie_headers: Vec<_> = response_headers
         .get_all(SET_COOKIE)
         .iter()
@@ -87,21 +77,14 @@ async fn test_oauth2_request_preparation_with_session() {
         .find(|cookie| cookie.contains(&*OAUTH2_CSRF_COOKIE_NAME))
         .expect("CSRF cookie should be set");
 
-    // Debug: print the actual cookie to see its format
     println!("Actual cookie: {csrf_cookie}");
 
     assert!(csrf_cookie.contains("HttpOnly"));
 
-    // Verify SameSite attribute matches the response mode
-    // form_post mode should use SameSite=None, query mode should use SameSite=Lax
-    let expected_samesite = match OAUTH2_RESPONSE_MODE.to_lowercase().as_str() {
-        "form_post" => "SameSite=None",
-        "query" => "SameSite=Lax",
-        _ => "SameSite=Lax", // Default fallback
-    };
+    // "query" mode → SameSite=Lax
     assert!(
-        csrf_cookie.contains(expected_samesite),
-        "Expected {expected_samesite} in cookie: {csrf_cookie}"
+        csrf_cookie.contains("SameSite=Lax"),
+        "Expected SameSite=Lax in cookie: {csrf_cookie}"
     );
 }
 
@@ -120,30 +103,20 @@ async fn test_oauth2_request_preparation_without_session() {
         http::HeaderValue::from_static("test-user-agent"),
     );
 
-    // Use the internal function with a test auth URL to avoid external dependencies
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let current_response_mode = OAUTH2_RESPONSE_MODE.as_str();
-    let result = prepare_oauth2_auth_request_with_params(
-        headers,
-        None,
-        test_auth_url,
-        current_response_mode,
-    )
-    .await;
+    let ctx = ProviderConfig::for_test(test_auth_url, "query");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, None).await;
 
     assert!(result.is_ok());
     let (auth_url, response_headers) = result.unwrap();
 
-    // Test the actual behavior, not implementation details
     let parsed_url = url::Url::parse(&auth_url).expect("Should generate valid URL");
 
-    // Test that auth URL starts with our test URL
     assert!(
         auth_url.starts_with(test_auth_url),
         "Should use provided auth URL"
     );
 
-    // Test OAuth2 parameters are present even without session
     let params: HashMap<String, String> = parsed_url.query_pairs().into_owned().collect();
     assert!(params.contains_key("client_id"), "Should include client_id");
     assert!(
@@ -173,7 +146,6 @@ async fn test_oauth2_request_preparation_without_session() {
         "Should use authorization code flow"
     );
 
-    // Test that CSRF cookie is set even without session
     assert!(
         response_headers.contains_key("set-cookie"),
         "Should set CSRF cookie"
@@ -193,6 +165,7 @@ async fn test_state_encoding_decoding_roundtrip() {
         pkce_id: "test_pkce_id".to_string(),
         misc_id: Some("test_misc_id".to_string()),
         mode_id: Some("signup".to_string()),
+        provider: "google".to_string(),
     };
 
     let encoded = encode_state(original_state.clone()).unwrap();
@@ -203,6 +176,7 @@ async fn test_state_encoding_decoding_roundtrip() {
     assert_eq!(original_state.pkce_id, decoded.pkce_id);
     assert_eq!(original_state.misc_id, decoded.misc_id);
     assert_eq!(original_state.mode_id, decoded.mode_id);
+    assert_eq!(original_state.provider, decoded.provider);
 }
 
 /// Test OAuth2State validation with invalid base64 input
@@ -235,7 +209,6 @@ async fn test_state_validation_invalid_base64() {
 ///
 #[tokio::test]
 async fn test_state_validation_invalid_json() {
-    // Create invalid JSON by encoding invalid data
     let invalid_json = base64url_encode(b"not valid json".to_vec()).unwrap();
     let result = crate::OAuth2State::new(invalid_json);
 
@@ -266,15 +239,14 @@ async fn test_oauth2_csrf_cookie_samesite_form_post_mode() {
     );
 
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let result =
-        prepare_oauth2_auth_request_with_params(headers, None, test_auth_url, "form_post").await;
+    let ctx = ProviderConfig::for_test(test_auth_url, "form_post");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, None).await;
 
     assert!(result.is_ok());
     let (_, response_headers) = result.unwrap();
 
     let csrf_cookie = extract_csrf_cookie(&response_headers);
 
-    // Verify security attributes
     assert!(
         csrf_cookie.contains("HttpOnly"),
         "Cookie should be HttpOnly"
@@ -282,7 +254,6 @@ async fn test_oauth2_csrf_cookie_samesite_form_post_mode() {
     assert!(csrf_cookie.contains("Secure"), "Cookie should be Secure");
     assert!(csrf_cookie.contains("Path=/"), "Cookie should have Path=/");
 
-    // Verify SameSite=None for form_post mode
     assert!(
         csrf_cookie.contains("SameSite=None"),
         "form_post mode should use SameSite=None for cross-origin POST requests. Cookie: {csrf_cookie}"
@@ -304,15 +275,14 @@ async fn test_oauth2_csrf_cookie_samesite_query_mode() {
     );
 
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let result =
-        prepare_oauth2_auth_request_with_params(headers, None, test_auth_url, "query").await;
+    let ctx = ProviderConfig::for_test(test_auth_url, "query");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, None).await;
 
     assert!(result.is_ok());
     let (_, response_headers) = result.unwrap();
 
     let csrf_cookie = extract_csrf_cookie(&response_headers);
 
-    // Verify security attributes
     assert!(
         csrf_cookie.contains("HttpOnly"),
         "Cookie should be HttpOnly"
@@ -320,7 +290,6 @@ async fn test_oauth2_csrf_cookie_samesite_query_mode() {
     assert!(csrf_cookie.contains("Secure"), "Cookie should be Secure");
     assert!(csrf_cookie.contains("Path=/"), "Cookie should have Path=/");
 
-    // Verify SameSite=Lax for query mode
     assert!(
         csrf_cookie.contains("SameSite=Lax"),
         "query mode should use SameSite=Lax for redirect-based flows. Cookie: {csrf_cookie}"
@@ -342,15 +311,14 @@ async fn test_oauth2_csrf_cookie_samesite_unknown_mode() {
     );
 
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let result =
-        prepare_oauth2_auth_request_with_params(headers, None, test_auth_url, "unknown_mode").await;
+    let ctx = ProviderConfig::for_test(test_auth_url, "unknown_mode");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, None).await;
 
     assert!(result.is_ok());
     let (_, response_headers) = result.unwrap();
 
     let csrf_cookie = extract_csrf_cookie(&response_headers);
 
-    // Verify security attributes
     assert!(
         csrf_cookie.contains("HttpOnly"),
         "Cookie should be HttpOnly"
@@ -358,7 +326,6 @@ async fn test_oauth2_csrf_cookie_samesite_unknown_mode() {
     assert!(csrf_cookie.contains("Secure"), "Cookie should be Secure");
     assert!(csrf_cookie.contains("Path=/"), "Cookie should have Path=/");
 
-    // Verify SameSite=Lax as default for unknown modes
     assert!(
         csrf_cookie.contains("SameSite=Lax"),
         "Unknown response mode should default to SameSite=Lax. Cookie: {csrf_cookie}"
@@ -368,7 +335,7 @@ async fn test_oauth2_csrf_cookie_samesite_unknown_mode() {
 /// Test CSRF cookie SameSite attribute configuration based on current config
 ///
 /// This integration test verifies that CSRF cookies are configured with appropriate SameSite
-/// attributes based on the actual OAuth2 response mode configuration.
+/// attributes based on the OAuth2 response mode set to "query" (matching .env_test).
 ///
 #[tokio::test]
 async fn test_oauth2_csrf_cookie_samesite_based_on_response_mode() {
@@ -380,23 +347,16 @@ async fn test_oauth2_csrf_cookie_samesite_based_on_response_mode() {
         http::HeaderValue::from_static("test-user-agent"),
     );
 
-    // Use the internal function with a test auth URL to avoid external dependencies
     let test_auth_url = "https://test.example.com/oauth/authorize";
-    let current_response_mode = OAUTH2_RESPONSE_MODE.as_str();
-    let result = prepare_oauth2_auth_request_with_params(
-        headers,
-        None,
-        test_auth_url,
-        current_response_mode,
-    )
-    .await;
+    // .env_test sets OAUTH2_RESPONSE_MODE=query
+    let ctx = ProviderConfig::for_test(test_auth_url, "query");
+    let result = prepare_oauth2_auth_request_inner(&ctx, headers, None).await;
 
     assert!(result.is_ok());
     let (_, response_headers) = result.unwrap();
 
     let csrf_cookie = extract_csrf_cookie(&response_headers);
 
-    // Verify the cookie has required security attributes
     assert!(
         csrf_cookie.contains("HttpOnly"),
         "Cookie should be HttpOnly"
@@ -404,28 +364,11 @@ async fn test_oauth2_csrf_cookie_samesite_based_on_response_mode() {
     assert!(csrf_cookie.contains("Secure"), "Cookie should be Secure");
     assert!(csrf_cookie.contains("Path=/"), "Cookie should have Path=/");
 
-    // Verify SameSite attribute matches the configured response mode
-    let current_mode = OAUTH2_RESPONSE_MODE.to_lowercase();
-    match current_mode.as_str() {
-        "form_post" => {
-            assert!(
-                csrf_cookie.contains("SameSite=None"),
-                "form_post mode should use SameSite=None for cross-origin POST requests. Cookie: {csrf_cookie}"
-            );
-        }
-        "query" => {
-            assert!(
-                csrf_cookie.contains("SameSite=Lax"),
-                "query mode should use SameSite=Lax for redirect-based flows. Cookie: {csrf_cookie}"
-            );
-        }
-        _ => {
-            assert!(
-                csrf_cookie.contains("SameSite=Lax"),
-                "Unknown response mode should default to SameSite=Lax. Cookie: {csrf_cookie}"
-            );
-        }
-    }
+    // "query" mode → SameSite=Lax
+    assert!(
+        csrf_cookie.contains("SameSite=Lax"),
+        "query mode should use SameSite=Lax for redirect-based flows. Cookie: {csrf_cookie}"
+    );
 }
 
 /// Helper function to extract CSRF cookie from response headers

--- a/oauth2_passkey/src/oauth2/main/fedcm.rs
+++ b/oauth2_passkey/src/oauth2/main/fedcm.rs
@@ -1,10 +1,10 @@
 use chrono::{Duration, Utc};
 
-use super::idtoken::{IdInfo, verify_idtoken_with_algorithm};
+use super::idtoken::{OidcIdInfo, verify_idtoken_with_algorithm};
 use super::utils::{generate_store_token, verify_and_consume_nonce};
 
 use crate::oauth2::OAuth2Error;
-use crate::oauth2::config::OAUTH2_GOOGLE_CLIENT_ID;
+use crate::oauth2::provider::ProviderConfig;
 use crate::oauth2::types::{FedCMNonceResponse, TokenType};
 
 /// TTL for FedCM nonce tokens (seconds)
@@ -34,14 +34,14 @@ pub async fn prepare_fedcm_nonce() -> Result<FedCMNonceResponse, OAuth2Error> {
 /// 2. Audience, issuer, and expiration validation
 /// 3. Nonce verification against the cached value (single-use: removed after verification)
 pub(crate) async fn validate_fedcm_token(
+    ctx: &ProviderConfig,
     token: &str,
     nonce_id: &str,
-) -> Result<IdInfo, OAuth2Error> {
+) -> Result<OidcIdInfo, OAuth2Error> {
     // 1. Verify JWT signature, audience, issuer, expiration
-    let (idinfo, _algorithm) =
-        verify_idtoken_with_algorithm(token.to_string(), OAUTH2_GOOGLE_CLIENT_ID.clone())
-            .await
-            .map_err(|e| OAuth2Error::IdToken(e.to_string()))?;
+    let (idinfo, _algorithm) = verify_idtoken_with_algorithm(ctx, token.to_string())
+        .await
+        .map_err(|e| OAuth2Error::IdToken(e.to_string()))?;
 
     // 2. Verify and consume nonce (single-use)
     verify_and_consume_nonce(nonce_id, idinfo.nonce.as_deref()).await?;

--- a/oauth2_passkey/src/oauth2/main/idtoken.rs
+++ b/oauth2_passkey/src/oauth2/main/idtoken.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
-use crate::oauth2::config::get_jwks_url;
+use crate::oauth2::provider::ProviderConfig;
 use crate::storage::{
     CacheData, CacheErrorConversion, CacheKey, CachePrefix, StorageError, get_data, remove_data,
     store_cache_keyed,
@@ -31,17 +31,21 @@ struct Jwk {
 
 #[allow(unused)]
 #[derive(Debug, Deserialize, Clone)]
-pub struct IdInfo {
+pub struct OidcIdInfo {
     pub iss: String,
     pub sub: String,
-    pub azp: String,
+    /// Google-specific; absent in many other OIDC providers (e.g. Auth0).
+    pub azp: Option<String>,
     pub aud: String,
     pub email: String,
-    pub email_verified: bool,
+    /// Some providers omit this claim; treat absence as unverified.
+    pub email_verified: Option<bool>,
     pub name: String,
     pub picture: Option<String>,
-    pub given_name: String,
-    pub family_name: String,
+    /// Absent in many non-Google OIDC providers.
+    pub given_name: Option<String>,
+    /// Absent in many non-Google OIDC providers.
+    pub family_name: Option<String>,
     pub locale: Option<String>,
     pub iat: i64,
     pub exp: i64,
@@ -234,14 +238,14 @@ fn convert_jwk_to_decoding_key(jwk: &Jwk) -> Result<DecodingKey, TokenVerificati
     }
 }
 
-fn decode_token(token: &str) -> Result<IdInfo, TokenVerificationError> {
+fn decode_token(token: &str) -> Result<OidcIdInfo, TokenVerificationError> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         return Err(TokenVerificationError::InvalidTokenFormat);
     }
     let payload = parts[1];
     let decoded_payload = decode_base64_url_safe(payload)?;
-    let idinfo: IdInfo = serde_json::from_slice(&decoded_payload)?;
+    let idinfo: OidcIdInfo = serde_json::from_slice(&decoded_payload)?;
     Ok(idinfo)
 }
 
@@ -265,18 +269,10 @@ fn verify_signature(
     }
 }
 
-pub(super) async fn _verify_idtoken(
-    token: String,
-    audience: String,
-) -> Result<IdInfo, TokenVerificationError> {
-    let (idinfo, _algorithm) = verify_idtoken_with_algorithm(token, audience).await?;
-    Ok(idinfo)
-}
-
 pub(super) async fn verify_idtoken_with_algorithm(
+    ctx: &ProviderConfig,
     token: String,
-    audience: String,
-) -> Result<(IdInfo, Algorithm), TokenVerificationError> {
+) -> Result<(OidcIdInfo, Algorithm), TokenVerificationError> {
     let header = jsonwebtoken::decode_header(&token)?;
 
     let kid = header
@@ -285,12 +281,12 @@ pub(super) async fn verify_idtoken_with_algorithm(
             "kid".to_string(),
         ))?;
     let alg = header.alg;
-    let idinfo: IdInfo = decode_token(&token)?;
+    let idinfo: OidcIdInfo = decode_token(&token)?;
 
     tracing::debug!("Algorithm from JWT header: {:?}", alg);
     tracing::debug!("Decoded id_token payload: {:#?}", idinfo);
 
-    let jwks_url = get_jwks_url().await?;
+    let jwks_url = ctx.jwks_url().await?;
     let jwks = fetch_jwks(&jwks_url).await?;
     let jwk = find_jwk(&jwks, &kid).ok_or(TokenVerificationError::NoMatchingKey)?;
 
@@ -301,14 +297,15 @@ pub(super) async fn verify_idtoken_with_algorithm(
         return Err(TokenVerificationError::InvalidTokenSignature);
     }
 
-    if idinfo.aud != audience {
+    let audience = &ctx.client_id;
+    if idinfo.aud != *audience {
         return Err(TokenVerificationError::InvalidTokenAudience(
-            audience,
+            audience.clone(),
             idinfo.aud.to_string(),
         ));
     }
 
-    let expected_issuer = crate::oauth2::config::get_expected_issuer().await?;
+    let expected_issuer = ctx.expected_issuer().await?;
     if idinfo.iss != expected_issuer {
         return Err(TokenVerificationError::InvalidTokenIssuer(
             idinfo.iss.to_string(),

--- a/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
@@ -400,11 +400,11 @@ fn test_decode_token_invalid_json_payload() {
 /// Test token decoding with valid payload
 ///
 /// This test verifies that `decode_token` successfully decodes a token with a valid
-/// JSON payload, creating a proper IdInfo struct with the expected field values.
+/// JSON payload, creating a proper OidcIdInfo struct with the expected field values.
 ///
 #[test]
 fn test_decode_token_valid_payload() {
-    // Create a valid IdInfo JSON payload
+    // Create a valid OidcIdInfo JSON payload
     let id_info_json = r#"{
         "iss": "https://accounts.google.com",
         "sub": "123456789",
@@ -429,7 +429,7 @@ fn test_decode_token_valid_payload() {
     assert_eq!(id_info.iss, "https://accounts.google.com");
     assert_eq!(id_info.sub, "123456789");
     assert_eq!(id_info.email, "test@example.com");
-    assert!(id_info.email_verified);
+    assert_eq!(id_info.email_verified, Some(true));
     assert_eq!(id_info.name, "Test User");
 }
 

--- a/oauth2_passkey/src/oauth2/main/mod.rs
+++ b/oauth2_passkey/src/oauth2/main/mod.rs
@@ -1,15 +1,17 @@
 mod core;
 mod fedcm;
-mod google;
 mod idtoken;
+mod oidc;
 mod utils;
 
 pub use core::prepare_oauth2_auth_request;
 pub use fedcm::prepare_fedcm_nonce;
 
+#[cfg(test)]
+pub(crate) use core::prepare_oauth2_auth_request_inner;
 pub(crate) use core::{csrf_checks, get_idinfo_userinfo};
 pub(crate) use fedcm::validate_fedcm_token;
-pub(crate) use idtoken::IdInfo;
+pub(crate) use idtoken::OidcIdInfo;
 
 pub(crate) use utils::{
     decode_state, delete_session_and_misc_token_from_store, get_mode_from_stored_session,

--- a/oauth2_passkey/src/oauth2/main/oidc.rs
+++ b/oauth2_passkey/src/oauth2/main/oidc.rs
@@ -1,16 +1,15 @@
-use crate::oauth2::config::{
-    OAUTH2_GOOGLE_CLIENT_ID, OAUTH2_GOOGLE_CLIENT_SECRET, OAUTH2_REDIRECT_URI, get_userinfo_url,
-};
 use crate::oauth2::errors::OAuth2Error;
-use crate::oauth2::types::{GoogleUserInfo, OidcTokenResponse};
+use crate::oauth2::provider::ProviderConfig;
+use crate::oauth2::types::{OidcTokenResponse, OidcUserInfo};
 
 use crate::utils::get_client;
 
-pub(super) async fn fetch_user_data_from_google(
+pub(super) async fn fetch_userinfo(
+    ctx: &ProviderConfig,
     access_token: String,
-) -> Result<GoogleUserInfo, OAuth2Error> {
+) -> Result<OidcUserInfo, OAuth2Error> {
     let client = get_client();
-    let userinfo_url = get_userinfo_url().await?;
+    let userinfo_url = ctx.userinfo_url().await?;
     let response = client
         .get(&userinfo_url)
         .bearer_auth(access_token)
@@ -24,7 +23,7 @@ pub(super) async fn fetch_user_data_from_google(
         .map_err(|e| OAuth2Error::FetchUserInfo(e.to_string()))?;
 
     tracing::debug!("Response Body: {:#?}", response_body);
-    let user_data: GoogleUserInfo = serde_json::from_str(&response_body)
+    let user_data: OidcUserInfo = serde_json::from_str(&response_body)
         .map_err(|e| OAuth2Error::Serde(format!("Failed to deserialize response body: {e}")))?;
 
     tracing::debug!("User data: {:#?}", user_data);
@@ -32,18 +31,19 @@ pub(super) async fn fetch_user_data_from_google(
 }
 
 pub(super) async fn exchange_code_for_token(
+    ctx: &ProviderConfig,
     code: String,
     code_verifier: String,
 ) -> Result<(String, String), OAuth2Error> {
     let client = get_client();
-    let token_url = crate::oauth2::config::get_token_url().await?;
+    let token_url = ctx.token_url().await?;
     let response = client
         .post(&token_url)
         .form(&[
             ("code", code),
-            ("client_id", OAUTH2_GOOGLE_CLIENT_ID.to_string()),
-            ("client_secret", OAUTH2_GOOGLE_CLIENT_SECRET.to_string()),
-            ("redirect_uri", OAUTH2_REDIRECT_URI.to_string()),
+            ("client_id", ctx.client_id.clone()),
+            ("client_secret", ctx.client_secret.clone()),
+            ("redirect_uri", ctx.redirect_uri.clone()),
             ("grant_type", "authorization_code".to_string()),
             ("code_verifier", code_verifier),
         ])

--- a/oauth2_passkey/src/oauth2/main/oidc/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/oidc/tests.rs
@@ -1,16 +1,16 @@
 use super::*;
-use crate::oauth2::types::{GoogleUserInfo, OidcTokenResponse};
+use crate::oauth2::types::{OidcTokenResponse, OidcUserInfo};
 use serde_json::json;
 
-/// Test successful deserialization of Google user info JSON
+/// Test successful deserialization of OIDC user info JSON
 ///
-/// This test verifies that `GoogleUserInfo` can be correctly deserialized from
+/// This test verifies that `OidcUserInfo` can be correctly deserialized from
 /// a JSON response containing all required fields. It creates a mock JSON response
 /// in memory and tests the serde deserialization.
 ///
 #[test]
-fn test_google_user_info_deserialization() {
-    // Test successful deserialization of Google user info
+fn test_oidc_userinfo_deserialization() {
+    // Test successful deserialization of OIDC user info
     let json_data = json!({
         "sub": "123456789",
         "email": "test@example.com",
@@ -24,7 +24,7 @@ fn test_google_user_info_deserialization() {
 
     let json_str = serde_json::to_string(&json_data)
         .expect("JSON serialization should not fail for valid data");
-    let user_info: Result<GoogleUserInfo, _> = serde_json::from_str(&json_str);
+    let user_info: Result<OidcUserInfo, _> = serde_json::from_str(&json_str);
 
     assert!(
         user_info.is_ok(),
@@ -98,13 +98,13 @@ fn test_oidc_token_response_missing_id_token() {
     );
 }
 
-/// Test Google user info deserialization with missing required fields
+/// Test OIDC user info deserialization with missing required fields
 ///
-/// This test verifies that deserializing Google user info JSON fails appropriately
+/// This test verifies that deserializing OIDC user info JSON fails appropriately
 /// when required fields are missing from the response.
 ///
 #[test]
-fn test_google_user_info_deserialization_missing_required_fields() {
+fn test_oidc_userinfo_deserialization_missing_required_fields() {
     // Test deserialization failure when required fields are missing
     let json_data = json!({
         "id": "123456789",
@@ -114,7 +114,7 @@ fn test_google_user_info_deserialization_missing_required_fields() {
     });
 
     let json_str = serde_json::to_string(&json_data).expect("JSON serialization should not fail");
-    let user_info: Result<GoogleUserInfo, _> = serde_json::from_str(&json_str);
+    let user_info: Result<OidcUserInfo, _> = serde_json::from_str(&json_str);
 
     assert!(
         user_info.is_err(),
@@ -122,17 +122,17 @@ fn test_google_user_info_deserialization_missing_required_fields() {
     );
 }
 
-/// Test Google user info deserialization with malformed JSON
+/// Test OIDC user info deserialization with malformed JSON
 ///
-/// This test verifies that attempting to deserialize malformed JSON to GoogleUserInfo
+/// This test verifies that attempting to deserialize malformed JSON to OidcUserInfo
 /// returns a JsonError as expected.
 ///
 #[test]
-fn test_google_user_info_deserialization_invalid_json() {
+fn test_oidc_userinfo_deserialization_invalid_json() {
     // Test deserialization failure with malformed JSON
     let invalid_json = r#"{"id": "123", "email":}"#; // Malformed JSON
 
-    let user_info: Result<GoogleUserInfo, _> = serde_json::from_str(invalid_json);
+    let user_info: Result<OidcUserInfo, _> = serde_json::from_str(invalid_json);
 
     assert!(
         user_info.is_err(),

--- a/oauth2_passkey/src/oauth2/main/utils/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/utils/tests.rs
@@ -44,6 +44,7 @@ fn test_encode_decode_state() {
         pkce_id: "pkce789".to_string(),
         misc_id: Some("misc123".to_string()),
         mode_id: Some("mode456".to_string()),
+        provider: "google".to_string(),
     };
 
     // Encode the state
@@ -63,6 +64,7 @@ fn test_encode_decode_state() {
     assert_eq!(decoded.pkce_id, "pkce789");
     assert_eq!(decoded.misc_id, Some("misc123".to_string()));
     assert_eq!(decoded.mode_id, Some("mode456".to_string()));
+    assert_eq!(decoded.provider, "google");
 }
 
 /// Test state parameter encoding and decoding with minimal fields
@@ -81,6 +83,7 @@ fn test_encode_decode_state_minimal() {
         pkce_id: "pkce789".to_string(),
         misc_id: None,
         mode_id: None,
+        provider: "google".to_string(),
     };
 
     // Encode the state
@@ -537,6 +540,7 @@ async fn test_get_uid_from_stored_session_no_misc_id() {
         pkce_id: "pkce789".to_string(),
         misc_id: None,
         mode_id: None,
+        provider: "google".to_string(),
     };
 
     // Call the function
@@ -566,6 +570,7 @@ async fn test_get_uid_from_stored_session_token_not_found() {
         pkce_id: "pkce789".to_string(),
         misc_id: Some("nonexistent_misc_id".to_string()),
         mode_id: None,
+        provider: "google".to_string(),
     };
 
     // Call the function
@@ -595,6 +600,7 @@ async fn test_delete_session_and_misc_token_no_misc_id() {
         pkce_id: "pkce789".to_string(),
         misc_id: None,
         mode_id: None,
+        provider: "google".to_string(),
     };
 
     // Call the function
@@ -623,6 +629,7 @@ async fn test_delete_session_and_misc_token_token_not_found() {
         pkce_id: "pkce789".to_string(),
         misc_id: Some("nonexistent_misc_id".to_string()),
         mode_id: None,
+        provider: "google".to_string(),
     };
 
     // Call the function

--- a/oauth2_passkey/src/oauth2/mod.rs
+++ b/oauth2_passkey/src/oauth2/mod.rs
@@ -14,6 +14,7 @@ mod config;
 mod discovery;
 mod errors;
 mod main;
+pub(crate) mod provider;
 mod storage;
 mod types;
 
@@ -25,10 +26,13 @@ pub use types::{
 };
 
 use crate::storage::CacheErrorConversion;
-pub(crate) use config::{OAUTH2_CSRF_COOKIE_NAME, OAUTH2_RESPONSE_MODE, get_auth_url};
+pub(crate) use config::OAUTH2_CSRF_COOKIE_NAME;
 pub(crate) use errors::OAuth2Error;
 pub(crate) use types::{StateParams, StoredToken};
+pub(crate) use types::{oauth2_account_from_idinfo, oauth2_account_from_userinfo};
 
+#[cfg(test)]
+pub(crate) use main::prepare_oauth2_auth_request_inner;
 pub(crate) use main::{
     csrf_checks, decode_state, delete_session_and_misc_token_from_store, get_idinfo_userinfo,
     get_mode_from_stored_session, get_uid_from_stored_session_by_state_param, validate_fedcm_token,
@@ -40,11 +44,25 @@ pub(crate) use storage::OAuth2Store;
 pub(crate) use types::{AccountId, AccountSearchField};
 
 pub(crate) async fn init() -> Result<(), errors::OAuth2Error> {
-    // Validate required and optional environment variables early
-    let _ = *config::OAUTH2_REDIRECT_URI; // This will validate ORIGIN
-    let _ = *config::OAUTH2_GOOGLE_CLIENT_ID;
-    let _ = *config::OAUTH2_GOOGLE_CLIENT_SECRET;
-    let _ = *config::OAUTH2_RESPONSE_MODE;
+    // Validate required env vars at startup (fail fast before serving requests).
+    // We do NOT force-initialize GOOGLE_PROVIDER here so that tests can override
+    // env vars (e.g. OAUTH2_ISSUER_URL) before the first provider access.
+    if std::env::var("OAUTH2_GOOGLE_CLIENT_ID").is_err() {
+        return Err(errors::OAuth2Error::Validation(
+            "OAUTH2_GOOGLE_CLIENT_ID must be set".to_string(),
+        ));
+    }
+    if std::env::var("OAUTH2_GOOGLE_CLIENT_SECRET").is_err() {
+        return Err(errors::OAuth2Error::Validation(
+            "OAUTH2_GOOGLE_CLIENT_SECRET must be set".to_string(),
+        ));
+    }
+    if std::env::var("ORIGIN").is_err() {
+        return Err(errors::OAuth2Error::Validation(
+            "ORIGIN must be set".to_string(),
+        ));
+    }
+
     let _ = *config::OAUTH2_CSRF_COOKIE_NAME;
     let _ = *config::OAUTH2_CSRF_COOKIE_MAX_AGE;
 

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -1,0 +1,212 @@
+use std::{
+    env,
+    sync::{LazyLock, OnceLock},
+};
+
+use crate::config::O2P_ROUTE_PREFIX;
+use crate::oauth2::discovery::{OidcDiscoveryDocument, OidcDiscoveryError, fetch_oidc_discovery};
+
+/// Identifies a supported OAuth2/OIDC provider.
+///
+/// Adding a new provider requires four lock-step edits, all in this file:
+/// 1. A new variant here
+/// 2. A new arm in `as_str`
+/// 3. A new arm in `from_path_segment`
+/// 4. A corresponding static (`LazyLock<ProviderConfig>` or
+///    `LazyLock<Option<ProviderConfig>>`) and a new arm in `provider_for`
+///
+/// Reserved names that must never become enum variants (they collide with
+/// existing literal routes under `/oauth2/*`):
+/// "authorized", "accounts", "fedcm", "popup_close", "oauth2.js"
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ProviderKind {
+    Google,
+    // Step 2: Auth0,
+}
+
+impl ProviderKind {
+    pub(crate) const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Google => "google",
+            // Self::Auth0 => "auth0",
+        }
+    }
+
+    /// Parse a URL path segment (e.g. "google") into a `ProviderKind`.
+    /// Returns `None` for unsupported values.
+    pub(crate) fn from_path_segment(s: &str) -> Option<Self> {
+        match s {
+            "google" => Some(Self::Google),
+            // "auth0"  => Some(Self::Auth0),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ProviderKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Per-provider OAuth2/OIDC configuration.
+///
+/// Each instance holds all configuration needed for one provider:
+/// credentials, computed endpoint URLs (via per-instance OIDC discovery),
+/// and response-mode settings.
+///
+/// The `discovery` field uses `OnceLock` with a "first write wins" strategy,
+/// matching the existing global `OIDC_DISCOVERY_CACHE` behaviour.  Concurrent
+/// first-access races may cause redundant fetches but always result in
+/// correct state.
+///
+/// **`ProviderConfig` is `pub(crate)`**: it never appears in the public API of
+/// `oauth2_passkey`.  The axum-crate boundary uses `&str`; parsing and config
+/// resolution happen inside this crate.
+pub(crate) struct ProviderConfig {
+    pub(crate) kind: ProviderKind,
+    pub(crate) client_id: String,
+    pub(crate) client_secret: String,
+    /// Base issuer URL used for OIDC discovery (trailing slash stripped).
+    pub(crate) issuer_url: String,
+    /// Redirect URI registered in the IdP console.
+    /// Built as `{ORIGIN}{O2P_ROUTE_PREFIX}/oauth2/{provider}/authorized`.
+    pub(crate) redirect_uri: String,
+    pub(crate) response_mode: String,
+    /// Precomputed query-string fragment appended to the authorization URL.
+    /// Starts with `&` to match the existing format string in core.rs.
+    pub(crate) query_string: String,
+    /// Per-provider OIDC discovery document cache.
+    pub(crate) discovery: OnceLock<OidcDiscoveryDocument>,
+}
+
+impl ProviderConfig {
+    async fn get_or_fetch_discovery(&self) -> Result<&OidcDiscoveryDocument, OidcDiscoveryError> {
+        if let Some(cached) = self.discovery.get() {
+            return Ok(cached);
+        }
+
+        tracing::debug!(
+            provider = %self.kind,
+            "Fetching OIDC discovery for issuer: {}",
+            self.issuer_url
+        );
+        let document = fetch_oidc_discovery(&self.issuer_url).await?;
+
+        // First write wins in case of concurrent access
+        let _ = self.discovery.set(document);
+
+        self.discovery.get().ok_or_else(|| {
+            OidcDiscoveryError::CacheError("Failed to cache discovery document".to_string())
+        })
+    }
+
+    pub(crate) async fn auth_url(&self) -> Result<String, OidcDiscoveryError> {
+        let doc = self.get_or_fetch_discovery().await?;
+        Ok(doc.authorization_endpoint.clone())
+    }
+
+    pub(crate) async fn token_url(&self) -> Result<String, OidcDiscoveryError> {
+        let doc = self.get_or_fetch_discovery().await?;
+        Ok(doc.token_endpoint.clone())
+    }
+
+    pub(crate) async fn jwks_url(&self) -> Result<String, OidcDiscoveryError> {
+        let doc = self.get_or_fetch_discovery().await?;
+        Ok(doc.jwks_uri.clone())
+    }
+
+    pub(crate) async fn userinfo_url(&self) -> Result<String, OidcDiscoveryError> {
+        let doc = self.get_or_fetch_discovery().await?;
+        Ok(doc.userinfo_endpoint.clone())
+    }
+
+    pub(crate) async fn expected_issuer(&self) -> Result<String, OidcDiscoveryError> {
+        let doc = self.get_or_fetch_discovery().await?;
+        Ok(doc.issuer.clone())
+    }
+}
+
+/// Google provider — unconditional (panics at first access if env vars are missing,
+/// matching the previous `LazyLock<String>` behaviour).
+pub(crate) static GOOGLE_PROVIDER: LazyLock<ProviderConfig> = LazyLock::new(|| {
+    let client_id =
+        env::var("OAUTH2_GOOGLE_CLIENT_ID").expect("OAUTH2_GOOGLE_CLIENT_ID must be set");
+    let client_secret =
+        env::var("OAUTH2_GOOGLE_CLIENT_SECRET").expect("OAUTH2_GOOGLE_CLIENT_SECRET must be set");
+    let issuer_url =
+        env::var("OAUTH2_ISSUER_URL").unwrap_or_else(|_| "https://accounts.google.com".to_string());
+    let origin = env::var("ORIGIN").expect("Missing ORIGIN!");
+    let redirect_uri = format!(
+        "{}{}/oauth2/google/authorized",
+        origin,
+        O2P_ROUTE_PREFIX.as_str()
+    );
+    let response_mode = {
+        let mode = env::var("OAUTH2_RESPONSE_MODE").unwrap_or_else(|_| "form_post".to_string());
+        match mode.to_lowercase().as_str() {
+            "form_post" => "form_post".to_string(),
+            "query" => "query".to_string(),
+            _ => panic!("Invalid OAUTH2_RESPONSE_MODE '{mode}'. Must be 'form_post' or 'query'."),
+        }
+    };
+    let scope = env::var("OAUTH2_SCOPE").unwrap_or_else(|_| "openid+email+profile".to_string());
+    let response_type = env::var("OAUTH2_RESPONSE_TYPE").unwrap_or_else(|_| "code".to_string());
+    let query_string = format!(
+        "&response_type={}&scope={}&response_mode={}&access_type=online&prompt=consent",
+        response_type, scope, response_mode
+    );
+    ProviderConfig {
+        kind: ProviderKind::Google,
+        client_id,
+        client_secret,
+        issuer_url,
+        redirect_uri,
+        response_mode,
+        query_string,
+        discovery: OnceLock::new(),
+    }
+});
+
+// Step 2: Auth0 (optional — enabled by setting OAUTH2_AUTH0_CLIENT_ID)
+//
+// pub(crate) static AUTH0_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock::new(|| {
+//     let client_id = env::var("OAUTH2_AUTH0_CLIENT_ID").ok()?;
+//     let client_secret = env::var("OAUTH2_AUTH0_CLIENT_SECRET")
+//         .expect("OAUTH2_AUTH0_CLIENT_ID set but OAUTH2_AUTH0_CLIENT_SECRET missing");
+//     let issuer_url = env::var("OAUTH2_AUTH0_ISSUER_URL")
+//         .expect("OAUTH2_AUTH0_CLIENT_ID set but OAUTH2_AUTH0_ISSUER_URL missing");
+//     let origin = env::var("ORIGIN").expect("Missing ORIGIN!");
+//     let redirect_uri = format!(
+//         "{}{}/oauth2/auth0/authorized",
+//         origin, O2P_ROUTE_PREFIX.as_str()
+//     );
+//     let response_mode = env::var("OAUTH2_AUTH0_RESPONSE_MODE")
+//         .unwrap_or_else(|_| "form_post".to_string());
+//     let scope = env::var("OAUTH2_AUTH0_SCOPE")
+//         .unwrap_or_else(|_| "openid+email+profile".to_string());
+//     let response_type = "code".to_string();
+//     let query_string = format!(
+//         "&response_type={}&scope={}&response_mode={}&access_type=online&prompt=consent",
+//         response_type, scope, response_mode
+//     );
+//     Some(ProviderConfig {
+//         kind: ProviderKind::Auth0,
+//         client_id, client_secret, issuer_url, redirect_uri,
+//         response_mode, query_string, discovery: OnceLock::new(),
+//     })
+// });
+
+/// Resolve a `ProviderKind` to its `&'static ProviderConfig`.
+///
+/// Returns `None` if the provider is optional and not configured (its env vars
+/// are absent).  Google is unconditional, so this always returns `Some` for it.
+pub(crate) fn provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig> {
+    match kind {
+        ProviderKind::Google => Some(&GOOGLE_PROVIDER),
+        // Step 2: ProviderKind::Auth0 => AUTH0_PROVIDER.as_ref(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+impl ProviderConfig {
+    /// Build a `ProviderConfig` pointing at a local mock server.
+    ///
+    /// All discovery endpoints are pre-populated to `{base_url}/<path>` so no
+    /// network calls are made and the mock server does not need to serve
+    /// `/.well-known/openid-configuration`.
+    ///
+    /// `client_id` matches the `aud` claim emitted by `create_mock_jwt` in tests.
+    pub(crate) fn for_mock_server(base_url: &str) -> Self {
+        let discovery = OnceLock::new();
+        let _ = discovery.set(OidcDiscoveryDocument {
+            issuer: base_url.to_string(),
+            authorization_endpoint: format!("{base_url}/oauth2/auth"),
+            token_endpoint: format!("{base_url}/oauth2/token"),
+            userinfo_endpoint: format!("{base_url}/oauth2/userinfo"),
+            jwks_uri: format!("{base_url}/oauth2/v3/certs"),
+            scopes_supported: None,
+            response_types_supported: None,
+            grant_types_supported: None,
+            subject_types_supported: None,
+            id_token_signing_alg_values_supported: None,
+        });
+        let response_mode = "query";
+        let query_string = format!(
+            "&response_type=code&scope=openid+email+profile&response_mode={response_mode}&access_type=online&prompt=consent"
+        );
+        Self {
+            kind: ProviderKind::Google,
+            client_id: "test-client-id.apps.googleusercontent.com".to_string(),
+            client_secret: "test_secret".to_string(),
+            issuer_url: base_url.to_string(),
+            redirect_uri: format!("{base_url}/oauth2/google/authorized"),
+            response_mode: response_mode.to_string(),
+            query_string,
+            discovery,
+        }
+    }
+
+    /// Build a `ProviderConfig` for use in tests, with a pre-populated discovery
+    /// document so no network calls are made.
+    pub(crate) fn for_test(auth_url: &str, response_mode: &str) -> Self {
+        let discovery = OnceLock::new();
+        let _ = discovery.set(OidcDiscoveryDocument {
+            issuer: "https://accounts.google.com".to_string(),
+            authorization_endpoint: auth_url.to_string(),
+            token_endpoint: "https://test.example.com/token".to_string(),
+            userinfo_endpoint: "https://test.example.com/userinfo".to_string(),
+            jwks_uri: "https://test.example.com/.well-known/certs".to_string(),
+            scopes_supported: None,
+            response_types_supported: None,
+            grant_types_supported: None,
+            subject_types_supported: None,
+            id_token_signing_alg_values_supported: None,
+        });
+        let query_string = format!(
+            "&response_type=code&scope=openid+email+profile&response_mode={}&access_type=online&prompt=consent",
+            response_mode
+        );
+        Self {
+            kind: ProviderKind::Google,
+            client_id: "test_client_id".to_string(),
+            client_secret: "test_secret".to_string(),
+            issuer_url: "https://accounts.google.com".to_string(),
+            redirect_uri: "https://test.example.com/oauth2/google/authorized".to_string(),
+            response_mode: response_mode.to_string(),
+            query_string,
+            discovery,
+        }
+    }
+}

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -1,4 +1,88 @@
 use super::*;
+use crate::test_utils::run_child_without_env;
+
+// --- ProviderKind ---
+
+#[test]
+fn test_provider_kind_from_path_segment_known() {
+    assert_eq!(
+        ProviderKind::from_path_segment("google"),
+        Some(ProviderKind::Google)
+    );
+}
+
+#[test]
+fn test_provider_kind_from_path_segment_unknown() {
+    assert_eq!(ProviderKind::from_path_segment("github"), None);
+    assert_eq!(ProviderKind::from_path_segment(""), None);
+    assert_eq!(ProviderKind::from_path_segment("Google"), None); // case-sensitive
+}
+
+#[test]
+fn test_provider_kind_as_str() {
+    assert_eq!(ProviderKind::Google.as_str(), "google");
+}
+
+// --- provider_for ---
+
+#[test]
+fn test_provider_for_unknown_returns_none() {
+    // provider_for can only be called with ProviderKind variants;
+    // there is no way to pass an unknown kind at compile time.
+    // This test documents that Google resolves to Some (when env vars set)
+    // and that the function signature guarantees exhaustiveness.
+    // provider_for(Google) tested in test_google_provider_initialization below.
+    let _ = provider_for; // just ensure it compiles and is accessible
+}
+
+// --- GOOGLE_PROVIDER initialization ---
+
+#[test]
+fn test_google_provider_init_requires_client_id() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let _ = &*GOOGLE_PROVIDER;
+        return;
+    }
+    // Should panic when OAUTH2_GOOGLE_CLIENT_ID is missing
+    let output = run_child_without_env(
+        "oauth2::provider::tests::test_google_provider_init_requires_client_id",
+        "OAUTH2_GOOGLE_CLIENT_ID",
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("OAUTH2_GOOGLE_CLIENT_ID"));
+}
+
+#[test]
+fn test_google_provider_init_accepts_valid_env() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        assert_eq!(GOOGLE_PROVIDER.client_id, "test-client-id");
+        assert_eq!(GOOGLE_PROVIDER.kind, ProviderKind::Google);
+        assert_eq!(
+            provider_for(ProviderKind::Google).map(|p| p.kind),
+            Some(ProviderKind::Google)
+        );
+        return;
+    }
+    let exe = std::env::current_exe().unwrap();
+    let output = std::process::Command::new(&exe)
+        .args([
+            "oauth2::provider::tests::test_google_provider_init_accepts_valid_env",
+            "--exact",
+            "--nocapture",
+        ])
+        .env("__TEST_ENV_VAR_CHILD", "1")
+        .env("OAUTH2_GOOGLE_CLIENT_ID", "test-client-id")
+        .env("OAUTH2_GOOGLE_CLIENT_SECRET", "test-secret")
+        .env("ORIGIN", "https://example.com")
+        .output()
+        .expect("failed to run child process");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
 
 impl ProviderConfig {
     /// Build a `ProviderConfig` pointing at a local mock server.

--- a/oauth2_passkey/src/oauth2/types.rs
+++ b/oauth2_passkey/src/oauth2/types.rs
@@ -4,7 +4,7 @@ use serde_json::{Value, json};
 use sqlx::FromRow;
 
 use super::errors::OAuth2Error;
-use super::main::IdInfo as GoogleIdInfo;
+use super::main::OidcIdInfo;
 
 use crate::session::UserId;
 use crate::storage::CacheData;
@@ -59,63 +59,81 @@ impl Default for OAuth2Account {
     }
 }
 
-// The user data we'll get back from Google
+/// Userinfo endpoint response.
+///
+/// All fields except `sub`, `name`, and `email` are optional because
+/// non-Google OIDC providers may omit them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct GoogleUserInfo {
+pub(crate) struct OidcUserInfo {
     pub(crate) sub: String,
-    pub(crate) family_name: String,
+    pub(crate) family_name: Option<String>,
     pub name: String,
     pub picture: Option<String>,
     pub(crate) email: String,
-    pub(crate) given_name: String,
+    pub(crate) given_name: Option<String>,
     pub(crate) hd: Option<String>,
-    pub(crate) email_verified: bool,
+    pub(crate) email_verified: Option<bool>,
 }
 
-// Add these implementations
-impl From<GoogleUserInfo> for OAuth2Account {
-    fn from(google_user: GoogleUserInfo) -> Self {
-        Self {
-            sequence_number: None,  // Will be set by database
-            id: String::new(),      // Will be set during storage
-            user_id: String::new(), // Will be set during upsert process
-            name: google_user.name,
-            email: google_user.email,
-            picture: google_user.picture,
-            provider: "google".to_string(),
-            provider_user_id: format!("google_{}", google_user.sub),
-            metadata: json!({
-                "family_name": google_user.family_name,
-                "given_name": google_user.given_name,
-                "hd": google_user.hd,
-                "email_verified": google_user.email_verified,
-            }),
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
+/// Build an `OAuth2Account` from an ID token payload.
+///
+/// Free function rather than `impl From<OidcIdInfo>` because `From` takes only one
+/// argument and cannot accept the `provider_name` parameter.
+///
+/// `provider_name` is taken from the URL path (primary dispatch signal) and
+/// cross-checked against `StateParams.provider`.  It is **not** hardcoded,
+/// so DB rows reflect the actual provider that issued the token.
+pub(crate) fn oauth2_account_from_idinfo(
+    idinfo: &OidcIdInfo,
+    provider_name: &str,
+) -> OAuth2Account {
+    OAuth2Account {
+        sequence_number: None,
+        id: String::new(),
+        user_id: String::new(),
+        name: idinfo.name.clone(),
+        email: idinfo.email.clone(),
+        picture: idinfo.picture.clone(),
+        provider: provider_name.to_string(),
+        provider_user_id: format!("{}_{}", provider_name, idinfo.sub),
+        metadata: json!({
+            "family_name": idinfo.family_name,
+            "given_name": idinfo.given_name,
+            "hd": idinfo.hd,
+            "verified_email": idinfo.email_verified,
+        }),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     }
 }
 
-impl From<GoogleIdInfo> for OAuth2Account {
-    fn from(idinfo: GoogleIdInfo) -> Self {
-        Self {
-            sequence_number: None,  // Will be set by database
-            id: String::new(),      // Will be set during storage
-            user_id: String::new(), // Will be set during upsert process
-            name: idinfo.name,
-            email: idinfo.email,
-            picture: idinfo.picture,
-            provider: "google".to_string(),
-            provider_user_id: format!("google_{}", idinfo.sub),
-            metadata: json!({
-                "family_name": idinfo.family_name,
-                "given_name": idinfo.given_name,
-                "hd": idinfo.hd,
-                "verified_email": idinfo.email_verified,
-            }),
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
+/// Build an `OAuth2Account` from a userinfo endpoint response.
+///
+/// Free function rather than `impl From<OidcUserInfo>` because `From` takes only one
+/// argument and cannot accept the `provider_name` parameter.
+///
+/// See `oauth2_account_from_idinfo` for the `provider_name` semantics.
+pub(crate) fn oauth2_account_from_userinfo(
+    userinfo: &OidcUserInfo,
+    provider_name: &str,
+) -> OAuth2Account {
+    OAuth2Account {
+        sequence_number: None,
+        id: String::new(),
+        user_id: String::new(),
+        name: userinfo.name.clone(),
+        email: userinfo.email.clone(),
+        picture: userinfo.picture.clone(),
+        provider: provider_name.to_string(),
+        provider_user_id: format!("{}_{}", provider_name, userinfo.sub),
+        metadata: json!({
+            "family_name": userinfo.family_name,
+            "given_name": userinfo.given_name,
+            "hd": userinfo.hd,
+            "email_verified": userinfo.email_verified,
+        }),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     }
 }
 
@@ -126,6 +144,10 @@ pub(crate) struct StateParams {
     pub(crate) pkce_id: String,
     pub(crate) misc_id: Option<String>,
     pub(crate) mode_id: Option<String>,
+    /// Provider name embedded in state as a defense-in-depth cross-check.
+    /// The URL path (`/oauth2/{provider}/authorized`) is the primary dispatch
+    /// signal; this field is only used to detect URL/state mismatches.
+    pub(crate) provider: String,
 }
 
 #[derive(Serialize, Clone, Deserialize, Debug)]

--- a/oauth2_passkey/src/oauth2/types/tests.rs
+++ b/oauth2_passkey/src/oauth2/types/tests.rs
@@ -2,27 +2,27 @@ use super::*;
 use chrono::{Duration, Utc};
 use serde_json::json;
 
-/// Test conversion from GoogleUserInfo to OAuth2Account
+/// Test conversion from OidcUserInfo to OAuth2Account via free function
 ///
-/// This test verifies that a GoogleUserInfo struct can be correctly converted into
-/// an OAuth2Account using the From trait implementation. It creates a GoogleUserInfo
+/// This test verifies that a OidcUserInfo struct can be correctly converted into
+/// an OAuth2Account using `oauth2_account_from_userinfo`. It creates a OidcUserInfo
 /// object in memory with sample data and validates that all fields are properly
 /// mapped to the resulting OAuth2Account structure.
 ///
 #[test]
 fn test_from_google_user_info() {
-    let google_user = GoogleUserInfo {
+    let google_user = OidcUserInfo {
         sub: "12345".to_string(),
-        family_name: "Doe".to_string(),
+        family_name: Some("Doe".to_string()),
         name: "John Doe".to_string(),
         picture: Some("https://example.com/pic.jpg".to_string()),
         email: "john@example.com".to_string(),
-        given_name: "John".to_string(),
+        given_name: Some("John".to_string()),
         hd: Some("example.com".to_string()),
-        email_verified: true,
+        email_verified: Some(true),
     };
 
-    let account = OAuth2Account::from(google_user.clone());
+    let account = oauth2_account_from_userinfo(&google_user, "google");
 
     // Check that fields are correctly mapped
     assert_eq!(account.name, "John Doe");
@@ -42,28 +42,28 @@ fn test_from_google_user_info() {
     assert_eq!(metadata["email_verified"], json!(true));
 }
 
-/// Test conversion from GoogleIdInfo to OAuth2Account
+/// Test conversion from OidcIdInfo to OAuth2Account via free function
 ///
-/// This test verifies that a GoogleIdInfo struct can be correctly converted into
-/// an OAuth2Account using the From trait implementation. It creates a GoogleIdInfo
+/// This test verifies that a OidcIdInfo struct can be correctly converted into
+/// an OAuth2Account using `oauth2_account_from_idinfo`. It creates a OidcIdInfo
 /// object in memory with ID token claims and validates that all fields are properly
 /// mapped to the resulting OAuth2Account structure.
 ///
 #[test]
 fn test_from_google_id_info() {
-    // Create a mock GoogleIdInfo
-    let id_info = GoogleIdInfo {
+    // Create a mock OidcIdInfo
+    let id_info = OidcIdInfo {
         iss: "https://accounts.google.com".to_string(),
-        azp: "client_id".to_string(),
+        azp: Some("client_id".to_string()),
         aud: "client_id".to_string(),
         sub: "12345".to_string(),
         email: "john@example.com".to_string(),
-        email_verified: true,
+        email_verified: Some(true),
         at_hash: Some("hash".to_string()),
         name: "John Doe".to_string(),
         picture: Some("https://example.com/pic.jpg".to_string()),
-        given_name: "John".to_string(),
-        family_name: "Doe".to_string(),
+        given_name: Some("John".to_string()),
+        family_name: Some("Doe".to_string()),
         locale: Some("en".to_string()),
         iat: 0,
         exp: 0,
@@ -73,7 +73,7 @@ fn test_from_google_id_info() {
         hd: Some("example.com".to_string()),
     };
 
-    let account = OAuth2Account::from(id_info.clone());
+    let account = oauth2_account_from_idinfo(&id_info, "google");
 
     // Check that fields are correctly mapped
     assert_eq!(account.name, "John Doe");

--- a/oauth2_passkey_axum/src/oauth2.rs
+++ b/oauth2_passkey_axum/src/oauth2.rs
@@ -48,8 +48,14 @@ pub(super) fn router() -> Router {
 
 /// Returns 410 Gone for the old `/oauth2/authorized` route.
 /// Clients that followed the old redirect should update their redirect_uri.
-async fn gone() -> StatusCode {
-    StatusCode::GONE
+async fn gone() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::GONE,
+        Json(serde_json::json!({
+            "error": "callback URL moved",
+            "new_url_pattern": "/oauth2/{provider}/authorized"
+        })),
+    )
 }
 
 #[derive(Template)]

--- a/oauth2_passkey_axum/src/oauth2.rs
+++ b/oauth2_passkey_axum/src/oauth2.rs
@@ -23,8 +23,13 @@ use super::session::AuthUser;
 pub(super) fn router() -> Router {
     let router = Router::new()
         .route("/oauth2.js", get(serve_oauth2_js))
-        .route("/google", get(google_auth))
-        .route("/authorized", get(get_authorized).post(post_authorized))
+        .route("/{provider}", get(oauth2_initiate))
+        .route(
+            "/{provider}/authorized",
+            get(get_authorized).post(post_authorized),
+        )
+        // Keep the old route returning 410 Gone so bookmarked links get a clear signal.
+        .route("/authorized", get(gone).post(gone))
         .route("/popup_close", get(popup_close))
         .route("/accounts", get(list_oauth2_accounts))
         .route(
@@ -39,6 +44,12 @@ pub(super) fn router() -> Router {
     } else {
         router
     }
+}
+
+/// Returns 410 Gone for the old `/oauth2/authorized` route.
+/// Clients that followed the old redirect should update their redirect_uri.
+async fn gone() -> StatusCode {
+    StatusCode::GONE
 }
 
 #[derive(Template)]
@@ -88,7 +99,8 @@ async fn serve_oauth2_js() -> Result<Response, (StatusCode, String)> {
         .into_response_error()
 }
 
-async fn google_auth(
+async fn oauth2_initiate(
+    Path(provider): Path<String>,
     auth_user: Option<AuthUser>,
     headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
@@ -113,7 +125,7 @@ async fn google_auth(
         }
     }
 
-    let (auth_url, headers) = prepare_oauth2_auth_request(headers, mode.as_deref())
+    let (auth_url, headers) = prepare_oauth2_auth_request(&provider, headers, mode.as_deref())
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -121,11 +133,12 @@ async fn google_auth(
 }
 
 async fn get_authorized(
+    Path(provider): Path<String>,
     Query(query): Query<AuthResponse>,
     TypedHeader(cookies): TypedHeader<headers::Cookie>,
     headers: HeaderMap,
 ) -> (HeaderMap, Redirect) {
-    match get_authorized_core(&query, &cookies, &headers).await {
+    match get_authorized_core(&provider, &query, &cookies, &headers).await {
         Ok((response_headers, message)) => {
             let redirect_url = build_success_redirect_url(&message);
             (response_headers, Redirect::to(&redirect_url))
@@ -148,11 +161,12 @@ async fn get_authorized(
 /// 4. Therefore, we can only access headers (which may contain some cookies) but not the
 ///    typed Cookie header that would be available in a standard browser navigation
 async fn post_authorized(
+    Path(provider): Path<String>,
     headers: HeaderMap,
     TypedHeader(cookies): TypedHeader<headers::Cookie>,
     Form(form): Form<AuthResponse>,
 ) -> (HeaderMap, Redirect) {
-    match post_authorized_core(&form, &cookies, &headers).await {
+    match post_authorized_core(&provider, &form, &cookies, &headers).await {
         Ok((response_headers, message)) => {
             let redirect_url = build_success_redirect_url(&message);
             (response_headers, Redirect::to(&redirect_url))

--- a/oauth2_passkey_axum/tests-security/common/attack_scenarios.rs
+++ b/oauth2_passkey_axum/tests-security/common/attack_scenarios.rs
@@ -144,6 +144,26 @@ pub mod oauth2_attacks {
         URL_SAFE_NO_PAD.encode(pkce_bypass_state.to_string().as_bytes())
     }
 
+    /// Tamper the `provider` field in a real base64url-encoded state parameter.
+    ///
+    /// Decodes the state, replaces `state.provider` with `fake_provider`, then
+    /// re-encodes.  All other IDs (csrf_id, nonce_id, pkce_id) remain intact so
+    /// CSRF validation can still pass — the only difference is the provider name.
+    /// This is the exact attack that the provider cross-check is designed to block.
+    pub fn tamper_state_provider(real_state: &str, fake_provider: &str) -> String {
+        // Decode base64url
+        let decoded = URL_SAFE_NO_PAD
+            .decode(real_state)
+            .expect("real_state must be valid base64url");
+        // Parse JSON
+        let mut state: serde_json::Value =
+            serde_json::from_slice(&decoded).expect("decoded state must be valid JSON");
+        // Replace provider field
+        state["provider"] = serde_json::Value::String(fake_provider.to_string());
+        // Re-encode
+        URL_SAFE_NO_PAD.encode(state.to_string().as_bytes())
+    }
+
     /// Create state with malicious redirect URI for redirect validation bypass testing
     pub fn create_state_with_malicious_redirect(redirect_uri: &str) -> String {
         let malicious_redirect_state = json!({

--- a/oauth2_passkey_axum/tests-security/cross_flow_security.rs
+++ b/oauth2_passkey_axum/tests-security/cross_flow_security.rs
@@ -162,7 +162,7 @@ async fn test_consolidated_cross_flow_session_attacks() -> Result<(), Box<dyn st
     let response = setup
         .browser
         .post_form(
-            "/auth/oauth2/authorized",
+            "/auth/oauth2/google/authorized",
             &[("code", "test_code"), ("state", "test_state")],
         )
         .await?;

--- a/oauth2_passkey_axum/tests-security/information_disclosure_security.rs
+++ b/oauth2_passkey_axum/tests-security/information_disclosure_security.rs
@@ -168,7 +168,7 @@ async fn test_consolidated_user_enumeration_attacks() -> Result<(), Box<dyn std:
         let response = setup
             .browser()
             .get(&format!(
-                "/auth/oauth2/authorized?code={auth_code}&state={state}"
+                "/auth/oauth2/google/authorized?code={auth_code}&state={state}"
             ))
             .await?;
 

--- a/oauth2_passkey_axum/tests-security/oauth2_security.rs
+++ b/oauth2_passkey_axum/tests-security/oauth2_security.rs
@@ -721,3 +721,65 @@ async fn test_consolidated_oauth2_advanced_attack_prevention()
     println!("🎯 === CONSOLIDATED OAUTH2 ADVANCED ATTACK PREVENTION TEST COMPLETED ===");
     Ok(())
 }
+
+/// **TEST**: Callback handler rejects URL/state provider mismatch as a security event
+///
+/// Verifies that submitting a state whose `provider` field does not match the URL
+/// path provider is rejected before any token exchange occurs.
+///
+/// Attack scenario:
+/// 1. Attacker starts a Google OAuth2 flow (obtains a real state with provider="google")
+/// 2. Attacker replaces `state.provider` with "auth0" but keeps the csrf_id intact
+/// 3. Attacker submits the tampered state to the Google callback URL
+/// 4. The server must detect the mismatch and reject the request as a security event
+///    — it must NOT proceed to the token exchange
+#[tokio::test]
+async fn test_oauth2_provider_mismatch_rejected_as_security_event()
+-> Result<(), Box<dyn std::error::Error>> {
+    println!("🔒 === OAUTH2 PROVIDER MISMATCH SECURITY TEST ===");
+
+    let setup = OAuth2SecurityTestSetup::new().await?;
+
+    // Step 1: start a real Google OAuth2 flow to obtain a valid state + CSRF cookie
+    let real_state = setup.establish_csrf_session_and_extract_state().await?;
+    println!(
+        "🔧 Real state extracted (first 20 chars): {}",
+        &real_state[..real_state.len().min(20)]
+    );
+
+    // Step 2: tamper the state — replace provider="google" with provider="auth0"
+    // All other IDs (csrf_id, nonce_id, pkce_id) remain intact so CSRF validation
+    // would pass if the provider check did not exist.
+    let tampered_state = tamper_state_provider(&real_state, "auth0");
+    println!(
+        "🔧 Tampered state (first 20 chars): {}",
+        &tampered_state[..tampered_state.len().min(20)]
+    );
+
+    let valid_code = "valid_auth_code_123";
+    let valid_origin_headers = vec![
+        ("Origin", "http://127.0.0.1:9876"),
+        ("Referer", "http://127.0.0.1:9876/auth"),
+    ];
+
+    // Step 3: submit the tampered state to the Google callback URL
+    // The CSRF cookie from the real flow is present in the browser jar.
+    let response = setup
+        .oauth2_callback_request(valid_code, &tampered_state, Some(&valid_origin_headers))
+        .await?;
+
+    let result = create_security_result_from_response(response).await?;
+
+    // Step 4: verify the request is rejected as a security event
+    assert_security_failure(
+        &result,
+        &ExpectedSecurityError::RedirectWithError,
+        "provider mismatch security test",
+    );
+    assert_no_session_established(&setup.browser).await;
+
+    setup.shutdown().await?;
+    println!("✅ PASSED: Provider mismatch properly rejected as security event");
+    println!("🎯 === OAUTH2 PROVIDER MISMATCH SECURITY TEST COMPLETED ===");
+    Ok(())
+}

--- a/oauth2_passkey_axum/tests-security/oauth2_security.rs
+++ b/oauth2_passkey_axum/tests-security/oauth2_security.rs
@@ -106,7 +106,7 @@ impl OAuth2SecurityTestSetup {
         let result = match response_mode.as_str() {
             "query" => {
                 // Query mode: use GET request with query parameters
-                let url = format!("/auth/oauth2/authorized?code={code}&state={state}");
+                let url = format!("/auth/oauth2/google/authorized?code={code}&state={state}");
                 match headers {
                     Some(headers) => self.browser.get_with_headers(&url, headers).await?,
                     None => self.browser.get(&url).await?,
@@ -119,7 +119,7 @@ impl OAuth2SecurityTestSetup {
                     Some(headers) => {
                         self.browser
                             .post_form_with_headers_old(
-                                "/auth/oauth2/authorized",
+                                "/auth/oauth2/google/authorized",
                                 &form_data,
                                 headers,
                             )
@@ -127,7 +127,7 @@ impl OAuth2SecurityTestSetup {
                     }
                     None => {
                         self.browser
-                            .post_form("/auth/oauth2/authorized", &form_data)
+                            .post_form("/auth/oauth2/google/authorized", &form_data)
                             .await?
                     }
                 }
@@ -385,7 +385,8 @@ async fn test_consolidated_oauth2_authorization_code_security()
         let valid_code = "valid_auth_code_123";
 
         // For form_post mode, using GET should be rejected
-        let get_url = format!("/auth/oauth2/authorized?code={valid_code}&state={real_state}");
+        let get_url =
+            format!("/auth/oauth2/google/authorized?code={valid_code}&state={real_state}");
         let valid_origin_headers = vec![
             ("Origin", "http://127.0.0.1:9876"),
             ("Referer", "http://127.0.0.1:9876/auth"),

--- a/oauth2_passkey_axum/tests-security/rate_limiting_security.rs
+++ b/oauth2_passkey_axum/tests-security/rate_limiting_security.rs
@@ -54,7 +54,7 @@ impl RateLimitingTestSetup {
             let response = self
                 .browser()
                 .get(&format!(
-                    "/auth/oauth2/authorized?code={invalid_code}&state={invalid_state}"
+                    "/auth/oauth2/google/authorized?code={invalid_code}&state={invalid_state}"
                 ))
                 .await?;
 

--- a/oauth2_passkey_axum/tests/common/mock_browser.rs
+++ b/oauth2_passkey_axum/tests/common/mock_browser.rs
@@ -163,7 +163,7 @@ impl MockBrowser {
         code: &str,
         state: &str,
     ) -> Result<Response, Box<dyn std::error::Error>> {
-        let path = format!("/auth/oauth2/authorized?code={code}&state={state}");
+        let path = format!("/auth/oauth2/google/authorized?code={code}&state={state}");
         let response = self.get(&path).await?;
         Ok(response)
     }

--- a/oauth2_passkey_axum/tests/integration/oauth2_flows.rs
+++ b/oauth2_passkey_axum/tests/integration/oauth2_flows.rs
@@ -100,7 +100,9 @@ async fn complete_oauth2_callback(
             // Query mode: GET request with query parameters and headers
             browser
                 .get_with_headers(
-                    &format!("/auth/oauth2/authorized?code={auth_code}&state={received_state}"),
+                    &format!(
+                        "/auth/oauth2/google/authorized?code={auth_code}&state={received_state}"
+                    ),
                     &[
                         ("Origin", oauth2_issuer_url),
                         ("Referer", &format!("{oauth2_issuer_url}/oauth2/auth")),
@@ -112,7 +114,7 @@ async fn complete_oauth2_callback(
             // Form_post mode: POST request with form data
             browser
                 .post_form_with_headers_old(
-                    "/auth/oauth2/authorized",
+                    "/auth/oauth2/google/authorized",
                     &[("code", auth_code), ("state", received_state)],
                     &[
                         ("Origin", oauth2_issuer_url),

--- a/oauth2_passkey_axum/tests/integration/oauth2_flows.rs
+++ b/oauth2_passkey_axum/tests/integration/oauth2_flows.rs
@@ -542,3 +542,38 @@ async fn test_oauth2_account_linking() -> Result<(), Box<dyn std::error::Error>>
     println!("🎯 === CONSOLIDATED OAUTH2 ACCOUNT LINKING TEST COMPLETED ===");
     Ok(())
 }
+
+/// Test that the old `/oauth2/authorized` callback URL returns 410 Gone.
+///
+/// When a client (or bookmarked redirect URI) hits the old single-provider
+/// callback URL, they should get a 410 with a JSON body pointing them to
+/// the new per-provider URL pattern.
+#[tokio::test]
+async fn test_old_oauth2_authorized_returns_410() -> Result<(), Box<dyn std::error::Error>> {
+    let setup = TestSetup::new().await?;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+
+    // GET /auth/oauth2/authorized — old single-provider callback URL
+    let response = client
+        .get(format!("{}/auth/oauth2/authorized", setup.server.base_url))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::GONE,
+        "Old /oauth2/authorized should return 410 Gone"
+    );
+
+    let body = response.text().await?;
+    assert!(
+        body.contains("new_url_pattern"),
+        "410 response should contain migration hint, got: {body}"
+    );
+
+    setup.shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
  - Add oauth2/provider.rs: ProviderConfig, ProviderKind, provider_for() as the single resolved provider context threaded through the call chain (B1 design pattern: resolve once at public API boundary)
  - Remove Google-specific LazyLock globals from config.rs; move client_id, client_secret, redirect_uri, response_mode into ProviderConfig
  - Rename GoogleUserInfo -> OidcUserInfo: userinfo endpoint is OIDC standard
  - Rename IdInfo -> OidcIdInfo: ID tokens are OIDC standard, not Google-specific
  - Rename google.rs -> oidc.rs, fetch_user_data_from_google -> fetch_userinfo: implementation was already provider-agnostic via ProviderConfig
  - Add doc comments explaining why free functions are used instead of impl From<OidcIdInfo> / From<OidcUserInfo> (From takes only one argument, cannot accept provider_name parameter)

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>