### PR TITLE
  feat: add Microsoft Entra ID as optional OIDC provider

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,10 +6,11 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (12)
+### Open (13)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
+| `20260420-0552` | medium | medium | [Add Microsoft Entra ID as OAuth2 Provider](open/20260420-0552-add-entra-provider.md) |
 | `20260420-0402` | medium | small | [Admin unlink/delete fails in demo mode ("Invalid user ID")](open/20260420-0402-admin-unlink-demo-mode.md) |
 | `20260226-2020` | high | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
 | `20260226-2018` | high | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |

--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,12 +6,13 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (12)
+### Open (17)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
 | `20260420-0402` | medium | small | [Admin unlink/delete fails in demo mode ("Invalid user ID")](open/20260420-0402-admin-unlink-demo-mode.md) |
 | `20260226-2020` | high | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
+| `20260420-1511` | high | medium | [Add Generic OIDC Provider Slots](open/20260420-1511-add-generic-oidc-provider.md) |
 | `20260226-2018` | high | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `20260226-2025` | high | large | [E2E Tests](open/20260226-2025-e2e-tests.md) |
 | `20260226-1814` | high | large | [Device Bound Session Credentials (DBSC) Support](open/20260226-1814-device-bound-session-credentials.md) |
@@ -19,9 +20,13 @@ This directory contains issue/task tracking files for the project.
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
+| `20260420-1456` | medium | medium | [Add LINE Login as OAuth2 Provider](open/20260420-1456-add-line-provider.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 | `20260331-1517` | low | small | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](open/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |
+| `20260420-1457` | low | large | [Add Sign in with Apple as OAuth2 Provider](open/20260420-1457-add-apple-provider.md) |
+| `20260420-1458` | low | large | [Add GitHub as OAuth2 Provider (non-OIDC)](open/20260420-1458-add-github-provider.md) |
+| `20260420-1521` | low | small | [Remove `OAUTH2_GOOGLE_USER` Dead Code and `oauth2_account_from_userinfo`](open/20260420-1521-remove-oauth2-google-user-dead-code.md) |
 
 ### Completed (60)
 

--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,11 +6,10 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (13)
+### Open (12)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
-| `20260420-0552` | medium | medium | [Add Microsoft Entra ID as OAuth2 Provider](open/20260420-0552-add-entra-provider.md) |
 | `20260420-0402` | medium | small | [Admin unlink/delete fails in demo mode ("Invalid user ID")](open/20260420-0402-admin-unlink-demo-mode.md) |
 | `20260226-2020` | high | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
 | `20260226-2018` | high | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
@@ -24,10 +23,11 @@ This directory contains issue/task tracking files for the project.
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 | `20260331-1517` | low | small | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](open/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |
 
-### Completed (59)
+### Completed (60)
 
 | ID | Title |
 |----|-------|
+| `20260420-0552` | [Add Microsoft Entra ID as OAuth2 Provider](completed/20260420-0552-add-entra-provider.md) |
 | `20260420-0307` | [Add Keycloak as OIDC Provider](completed/20260420-0307-add-keycloak-provider.md) |
 | `20260322-0927` | [User Deletion Lacks Atomicity Across Multiple Stores](completed/20260322-0927-user-deletion-atomicity.md) |
 | `20260321-1346` | [Review delete_old_entries Dead Code and Retention Policy](completed/20260321-1346-review-delete-old-entries-dead-code.md) |

--- a/.claude/issues/completed/20260420-0552-add-entra-provider.md
+++ b/.claude/issues/completed/20260420-0552-add-entra-provider.md
@@ -14,9 +14,9 @@
 
 ## Created: 2026-04-20-05-52
 
-## Closed:
+## Closed: 2026-04-20-14-37
 
-## Status: open
+## Status: completed
 
 ## Priority: medium
 
@@ -146,7 +146,7 @@ Env vars:
 - [x] Add new tests: preferred_username fallback, missing-both-errors path
 - [x] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
 - [x] Regression: Google / Auth0 / Keycloak login still work in `demo-both`
-- [ ] Commit Part 1
+- [x] Commit Part 1
 
 ### Part 2: Entra provider
 - [x] Add `Entra` variant + 6 lock-step edits in `provider.rs`
@@ -158,7 +158,7 @@ Env vars:
 - [x] End-to-end: Entra work account login succeeds, DB row has `provider = "entra"`
 - [x] End-to-end: Entra personal MS account login succeeds via `preferred_username` fallback
 - [x] Regression: mis-configured Entra (trigger set, secret missing) fails at startup
-- [ ] Commit Part 1 + Part 2
+- [x] Commit Part 1 + Part 2
 
 ## Decision Log
 
@@ -207,3 +207,34 @@ Env vars:
   sufficient for the realistic failure cases.
 
 ## Resolution
+
+Microsoft Entra ID is now available as a fourth optional OIDC provider. The
+implementation surfaced three latent issues that were fixed as part of the
+work:
+
+1. **OIDC type compliance** — `OidcUserInfo.email` / `.name` and
+   `OidcIdInfo.email` / `.name` were required (`String`) despite being
+   standard (not required) claims per OIDC Core 1.0. Relaxed to
+   `Option<String>`; added `preferred_username` as a documented fallback
+   with clear error paths when both are absent.
+2. **JWKS parsing** — `Jwk.alg` was required (`String`) but Entra's JWKS
+   endpoint omits it. Made optional with kty-derived defaults (`RSA` →
+   `RS256`, `EC` → `ES256`, `oct` → `HS256`).
+3. **Consumers tenant UUID** — Documented that `consumers` alias fails
+   issuer validation; users must configure the fixed UUID
+   (`9188040d-6c67-4c5b-b112-36a304b66dad`) for B2C personal-account
+   deployments.
+
+**Verified scenarios:**
+- Work/school account (single-tenant) login succeeds with `email` claim
+- Personal MS account login succeeds with `preferred_username` fallback
+- Mis-configured Entra (trigger set, dependencies missing) fails at startup
+- Regression: Google / Auth0 / Keycloak continue to work
+
+**Commits:**
+- `b75b2f7` feat: add Microsoft Entra ID as optional OIDC provider
+- `997dad7` docs: expand Entra setup guide for personal Microsoft accounts
+
+**Out of scope (potential follow-up):**
+- Multi-tenant issuer validation (`common` / `organizations` endpoints) to
+  support work + personal accounts in a single app registration

--- a/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
+++ b/.claude/issues/open/20260226-2020-expand-oauth2-providers.md
@@ -16,7 +16,7 @@
 
 ## Closed:
 
-## Status: open (Step 1 completed 2026-04-16; Step 2 completed 2026-04-20, pending LT screenshots + Phase 2+)
+## Status: open (Step 1 + 2 complete; Auth0/Keycloak/Entra shipped; LINE/Apple/GitHub tracked as sub-issues)
 
 ## Priority: high
 
@@ -24,22 +24,48 @@
 
 ## Description
 
-Currently only Google OAuth2/OIDC is supported. Add support for additional OAuth2 providers to expand the library's utility:
+Originally only Google OAuth2/OIDC was supported. This umbrella issue tracks
+expansion to additional providers so that the library is useful for a wider
+range of deployments.
 
-- **GitHub** - Popular for developer-facing applications
-- **Apple** - Required for iOS apps using third-party login
-- **Microsoft** (Azure AD / Entra ID) - Common in enterprise environments
+### Provider status
+
+| Provider | Flow | Status | Tracking issue |
+|----------|------|--------|----------------|
+| Google | OIDC | shipped (v0.5.1) | — (baseline) |
+| Auth0 | OIDC | shipped (v0.5.1) | Step 2 below |
+| Keycloak | OIDC | shipped | `20260420-0307` (completed) |
+| Microsoft Entra ID | OIDC | shipped | `20260420-0552` (completed) |
+| LINE | OIDC | planned | `20260420-1456` |
+| Apple | OIDC + dynamic JWT secret | planned | `20260420-1457` |
+| GitHub | plain OAuth2 (non-OIDC) | planned | `20260420-1458` |
+| Generic OIDC slots (Okta, Zitadel, AWS Cognito, Ory Hydra, Dex, Authelia, ...) | OIDC | planned | `20260420-1511` |
 
 ### Design Considerations
 
-- The existing provider system was designed with extensibility in mind (OIDC Discovery, typed `Provider` wrapper)
+- The provider system uses a fixed `ProviderKind` enum + per-variant
+  `LazyLock<Option<ProviderConfig>>` statics (Step 1, 2026-04-16). Adding a
+  new OIDC provider = 6 lock-step edits in `provider.rs` + UI + docs.
 - Each provider has slightly different OAuth2/OIDC implementations and quirks
-- Apple Sign-In has unique requirements (form_post response mode, private email relay)
-- GitHub uses OAuth2 but not full OIDC (no ID token by default)
+  (e.g. Entra omits `email` for personal accounts, JWKS omits `alg`).
+- Apple Sign-In has unique requirements: `response_mode=form_post` forced,
+  `client_secret` as ES256 JWT generated from a P8 private key, name/email
+  only in the initial authorization.
+- GitHub uses OAuth2 but not OIDC: no id_token, no discovery, no JWKS;
+  identity is fetched from `/user` and `/user/emails` REST endpoints. This
+  requires introducing a non-OIDC flow path alongside the existing OIDC one.
 
 ## Related Issues
 
-None
+Completed sub-issues:
+- `20260420-0307` Add Keycloak as OIDC Provider (completed)
+- `20260420-0552` Add Microsoft Entra ID as OAuth2 Provider (completed)
+
+Open sub-issues:
+- `20260420-1456` Add LINE Login as OAuth2 Provider
+- `20260420-1457` Add Sign in with Apple as OAuth2 Provider
+- `20260420-1458` Add GitHub as OAuth2 Provider (non-OIDC)
+- `20260420-1511` Add Generic OIDC Provider Slots
 
 ## Approach
 
@@ -246,25 +272,42 @@ Tests and verification:
 - [x] If any code change is needed here, mark Step 1 as incomplete and address (no code changes required)
 
 
-### Phase 2: GitHub (non-OIDC)
+### Additional OIDC providers (completed after Step 2)
 
-- [ ] Introduce `OAuth2Flow` trait with OIDC and non-OIDC implementations
-- [ ] GitHub flow: code exchange + `GET /user` + `GET /user/emails`, no id_token, no nonce
-- [ ] GitHub-specific claim mapping
-- [ ] Integration test with mocked GitHub API
+- [x] Add Keycloak as OIDC provider — see sub-issue `20260420-0307`
+- [x] Add Microsoft Entra ID as OIDC provider — see sub-issue `20260420-0552`
+  - Surfaced and fixed two latent issues: `OidcIdInfo` / `OidcUserInfo`
+    `email`/`name` relaxed to `Option<String>` with `preferred_username`
+    fallback; `Jwk.alg` relaxed to `Option<String>` with kty-derived default.
 
-### Phase 3: Apple Sign-In
+### Phase 2: LINE (OIDC — same pattern as Entra)
 
-- [ ] Force `response_mode=form_post` per instance
-- [ ] Generate `client_secret` as ES256 JWT from Apple private key
-- [ ] Extract name/email from initial form body (first authorization only)
-- [ ] Handle Apple private email relay
-- [ ] Integration test
+Tracked as sub-issue `20260420-1456`. Straightforward lock-step edits; no
+architectural changes required. ES256 is already supported; main caveat is
+LINE's email-permission approval requirement.
 
-### Phase 4: FedCM multi-provider (optional)
+### Phase 3: GitHub (non-OIDC) — was "Phase 2" in earlier revisions
+
+Tracked as sub-issue `20260420-1458`. Requires introducing a non-OIDC flow
+path (enum `ProviderFlow` or a trait abstraction) because GitHub does not
+issue id_tokens and has no discovery endpoint for end-user login.
+
+### Phase 4: Apple Sign-In — was "Phase 3" in earlier revisions
+
+Tracked as sub-issue `20260420-1457`. Requires introducing a dynamic-secret
+strategy (`ClientSecret::AppleJwt` with ES256 JWT generation from a P8
+private key, with caching).
+
+### Phase 5: FedCM multi-provider (optional)
 
 - [ ] Per-instance FedCM configURL
 - [ ] Frontend FedCM `providers: [...]` array support
+
+### Phase 6 (potential, not currently tracked): Multi-tenant Entra
+
+Support `common` / `organizations` Entra endpoints for work+personal mixed
+apps. Requires pattern-matching issuer URLs against a `{tenantid}` placeholder.
+See the Entra sub-issue's Decision Log for context.
 
 ## Decision Log
 

--- a/.claude/issues/open/20260420-0552-add-entra-provider.md
+++ b/.claude/issues/open/20260420-0552-add-entra-provider.md
@@ -136,29 +136,29 @@ Env vars:
 ## Implementation Tasks
 
 ### Part 1: Type relaxation
-- [ ] Relax `OidcUserInfo` (`email` / `name` → `Option<String>`, add `preferred_username`)
-- [ ] Relax `OidcIdInfo` (same)
-- [ ] Change `oauth2_account_from_userinfo` return type + fallback logic
-- [ ] Change `oauth2_account_from_idinfo` return type + fallback logic
-- [ ] Update call sites in `coordination/oauth2.rs` (`?` propagation)
-- [ ] Update call site in `coordination/oauth2/tests.rs`
-- [ ] Update existing tests in `types/tests.rs`
-- [ ] Add new tests: preferred_username fallback, missing-both-errors path
-- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
-- [ ] Regression: Google / Auth0 / Keycloak login still work in `demo-both`
+- [x] Relax `OidcUserInfo` (`email` / `name` → `Option<String>`, add `preferred_username`)
+- [x] Relax `OidcIdInfo` (same) + add `preferred_username`
+- [x] Change `oauth2_account_from_userinfo` return type + fallback logic
+- [x] Change `oauth2_account_from_idinfo` return type + fallback logic
+- [x] Update call sites in `coordination/oauth2.rs` (`?` propagation)
+- [x] Update call site in `coordination/oauth2/tests.rs`
+- [x] Update existing tests in `types/tests.rs`
+- [x] Add new tests: preferred_username fallback, missing-both-errors path
+- [x] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [x] Regression: Google / Auth0 / Keycloak login still work in `demo-both`
 - [ ] Commit Part 1
 
 ### Part 2: Entra provider
-- [ ] Add `Entra` variant + 6 lock-step edits in `provider.rs`
-- [ ] Add 2 tests in `provider/tests.rs`
-- [ ] Add `"entra"` arm in `provider_view`
-- [ ] Add CSS vars + `.btn-entra` styles
-- [ ] Write `docs/entra.md`
-- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
-- [ ] End-to-end: Entra work account login succeeds, DB row has `provider = "entra"`
-- [ ] End-to-end: Entra personal MS account login succeeds via `preferred_username` fallback
-- [ ] Regression: mis-configured Entra (trigger set, secret missing) fails at startup
-- [ ] Commit Part 2
+- [x] Add `Entra` variant + 6 lock-step edits in `provider.rs`
+- [x] Add 2 tests in `provider/tests.rs`
+- [x] Add `"entra"` arm in `provider_view`
+- [x] Add CSS vars + `.btn-entra` styles
+- [x] Write `docs/src/guides/entra.md`
+- [x] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [x] End-to-end: Entra work account login succeeds, DB row has `provider = "entra"`
+- [x] End-to-end: Entra personal MS account login succeeds via `preferred_username` fallback
+- [x] Regression: mis-configured Entra (trigger set, secret missing) fails at startup
+- [ ] Commit Part 1 + Part 2
 
 ## Decision Log
 
@@ -185,6 +185,16 @@ Env vars:
 - Reason: Multi-tenant issuer validation is non-trivial (pattern-match `{tenantid}` against
   the actual tenant ID from the id_token) and is orthogonal to the Entra-specific work.
   If demand appears, handle as a follow-up.
+
+### 2026-04-20: Made `Jwk.alg` optional to fix Entra JWKS parsing
+
+- Context: Entra's JWKS endpoint omits the `alg` field from key entries; the existing
+  `Jwk` struct had `alg: String` (required), causing serde deserialization to fail with
+  "error decoding response body" when the JWKS was fetched.
+- Decision: Changed `Jwk.alg` to `Option<String>`. `convert_jwk_to_decoding_key` falls
+  back to a `kty`-derived default (`RSA` → `RS256`, `EC` → `ES256`, `oct` → `HS256`).
+- Reason: The fix is minimal and backward-compatible. Google and other providers that
+  include `alg` continue to work unchanged; the fallback only activates when absent.
 
 ### 2026-04-20: Kept `OAuth2Account.email` / `.name` required
 

--- a/.claude/issues/open/20260420-0552-add-entra-provider.md
+++ b/.claude/issues/open/20260420-0552-add-entra-provider.md
@@ -1,0 +1,199 @@
+# Issue: Add Microsoft Entra ID as OAuth2 Provider
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-0552
+
+## Created: 2026-04-20-05-52
+
+## Closed:
+
+## Status: open
+
+## Priority: medium
+
+## Difficulty: medium
+
+## Description
+
+Add Microsoft Entra ID (formerly Azure AD) as a fourth optional OIDC provider alongside
+Google, Auth0, and Keycloak. Adding Entra surfaces a latent issue in the OIDC type
+definitions that must be fixed as a prerequisite:
+
+- `OidcUserInfo.email: String` and `OidcIdInfo.email: String` are required, but Entra does
+  not always return `email` as a top-level claim
+  - Personal Microsoft accounts: email only in `preferred_username`
+  - Work/school accounts without email attribute: `email` claim absent
+- With the current types, serde deserialization fails outright for these cases
+
+This is a latent OIDC-compliance bug: the spec lists `email` and `name` as standard
+claims, not required ones. Google / Auth0 / Keycloak all happened to return them
+reliably, masking the issue.
+
+The work therefore splits into two parts:
+
+1. **Type relaxation (prerequisite)** — make `email` / `name` optional in `OidcIdInfo` /
+   `OidcUserInfo`, add `preferred_username` as a documented fallback, and change
+   `oauth2_account_from_*` to return `Result<OAuth2Account, OAuth2Error>`.
+2. **Entra provider** — lock-step edits following the established Auth0/Keycloak pattern.
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: part of)
+- `20260420-0307` Add Keycloak as OIDC Provider (relationship: same pattern, completed)
+
+## Approach
+
+### Part 1: Type relaxation (must compile/test green before Part 2)
+
+**`oauth2_passkey/src/oauth2/types.rs`**
+- `OidcUserInfo.email: String` → `Option<String>`
+- `OidcUserInfo.name: String` → `Option<String>`
+- Add `preferred_username: Option<String>`
+- `oauth2_account_from_userinfo` returns `Result<OAuth2Account, OAuth2Error>`
+  - Email fallback: `userinfo.email.or(userinfo.preferred_username)`, else `OAuth2Error::Validation`
+  - Name fallback: `userinfo.name.unwrap_or(email.clone())`
+
+**`oauth2_passkey/src/oauth2/main/idtoken.rs`**
+- Same relaxation for `OidcIdInfo`
+- `OidcIdInfo` is `pub`; this is a breaking API change, acceptable pre-1.0 (v0.5.1-dev)
+
+**`oauth2_passkey/src/coordination/oauth2.rs`**
+- `?` propagation at lines 264-266 and 499
+- `impl From<OAuth2Error> for CoordinationError` already exists (`coordination/errors.rs:244`), so `?` works
+
+**Tests:**
+- Update existing `types/tests.rs` cases for new `Option<String>` shape + `Result` return
+- Add: `test_userinfo_uses_preferred_username_when_email_absent`
+- Add: `test_userinfo_missing_both_email_and_preferred_username_errors`
+- Add: `test_idinfo_uses_preferred_username_when_email_absent`
+
+### Part 2: Entra provider (lock-step edits, mirrors Keycloak)
+
+**`oauth2_passkey/src/oauth2/provider.rs`** — all 6 edits:
+1. `Entra` variant in `ProviderKind`
+2. Include in `ProviderKind::ALL`
+3. `as_str`: `Self::Entra => "entra"`
+4. `from_path_segment`: `"entra" => Some(Self::Entra)`
+5. `optional_env_contract`: trigger `OAUTH2_ENTRA_CLIENT_ID`, deps `OAUTH2_ENTRA_CLIENT_SECRET` + `OAUTH2_ENTRA_ISSUER_URL`
+6. `ENTRA_PROVIDER: LazyLock<Option<ProviderConfig>>` + `provider_for` arm
+
+Env vars:
+- `OAUTH2_ENTRA_CLIENT_ID` (trigger)
+- `OAUTH2_ENTRA_CLIENT_SECRET`
+- `OAUTH2_ENTRA_ISSUER_URL` = `https://login.microsoftonline.com/{tenant_id}/v2.0`
+- `OAUTH2_ENTRA_RESPONSE_MODE` (optional, default `form_post`)
+- `OAUTH2_ENTRA_SCOPE` (optional, default `openid+email+profile`)
+
+**`oauth2_passkey/src/oauth2/provider/tests.rs`**
+- `test_provider_kind_from_path_segment_entra`
+- `test_optional_env_contract_entra`
+
+**`oauth2_passkey_axum/src/oauth2.rs`**
+- New `"entra"` arm in `provider_view`: `display_name: "Microsoft"`, `button_class: "btn-oauth2 btn-entra"`
+
+**`oauth2_passkey_axum/static/o2p-base.css`**
+- CSS vars: `--o2p-entra: #0078D4` / `--o2p-entra-hover: #005A9E`
+- `.btn-entra` + `.btn-entra:hover` styles
+
+### Part 3: Docs
+
+**`docs/entra.md`** — follow `docs/keycloak.md` / `docs/auth0.md` structure:
+- Azure App Registration walk-through (tenant ID, client ID, secret)
+- Redirect URI: `{ORIGIN}/oauth2/entra/authorized`
+- Env var setup
+- **Single-tenant only** — `common` / `organizations` issuer URLs fail discovery issuer validation
+- **Email claim handling** — library falls back to `preferred_username`; work accounts should
+  have email attribute set or enable `email` optional claim in app registration
+- DB row assertion to confirm login
+
+### Suggested commits
+
+1. `refactor: make OIDC email/name optional and add preferred_username fallback`
+2. `feat: add Microsoft Entra ID as OAuth2 provider`
+
+## Related Files
+
+- `oauth2_passkey/src/oauth2/types.rs` — OidcUserInfo + conversion functions
+- `oauth2_passkey/src/oauth2/main/idtoken.rs` — OidcIdInfo
+- `oauth2_passkey/src/coordination/oauth2.rs` — call sites (lines 264-266, 499)
+- `oauth2_passkey/src/coordination/oauth2/tests.rs` — test call site (line 43)
+- `oauth2_passkey/src/oauth2/types/tests.rs` — existing + new tests
+- `oauth2_passkey/src/oauth2/provider.rs` — 6 lock-step edits
+- `oauth2_passkey/src/oauth2/provider/tests.rs` — 2 new tests
+- `oauth2_passkey_axum/src/oauth2.rs` — provider_view arm
+- `oauth2_passkey_axum/static/o2p-base.css` — CSS vars + button styles
+- `docs/entra.md` — new setup guide
+
+## Implementation Tasks
+
+### Part 1: Type relaxation
+- [ ] Relax `OidcUserInfo` (`email` / `name` → `Option<String>`, add `preferred_username`)
+- [ ] Relax `OidcIdInfo` (same)
+- [ ] Change `oauth2_account_from_userinfo` return type + fallback logic
+- [ ] Change `oauth2_account_from_idinfo` return type + fallback logic
+- [ ] Update call sites in `coordination/oauth2.rs` (`?` propagation)
+- [ ] Update call site in `coordination/oauth2/tests.rs`
+- [ ] Update existing tests in `types/tests.rs`
+- [ ] Add new tests: preferred_username fallback, missing-both-errors path
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] Regression: Google / Auth0 / Keycloak login still work in `demo-both`
+- [ ] Commit Part 1
+
+### Part 2: Entra provider
+- [ ] Add `Entra` variant + 6 lock-step edits in `provider.rs`
+- [ ] Add 2 tests in `provider/tests.rs`
+- [ ] Add `"entra"` arm in `provider_view`
+- [ ] Add CSS vars + `.btn-entra` styles
+- [ ] Write `docs/entra.md`
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] End-to-end: Entra work account login succeeds, DB row has `provider = "entra"`
+- [ ] End-to-end: Entra personal MS account login succeeds via `preferred_username` fallback
+- [ ] Regression: mis-configured Entra (trigger set, secret missing) fails at startup
+- [ ] Commit Part 2
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+### 2026-04-20: Chose Option A (type relaxation) over docs-only approach
+
+- Context: Investigation revealed that Entra does not reliably return `email` in standard
+  claims. Considered three options: (A) relax types + add `preferred_username` fallback,
+  (B) document strict setup requirements, (C) pick a different provider.
+- Decision: Option A.
+- Reason: The current struct shape is a latent OIDC spec-compliance bug regardless of
+  Entra. `email`/`name` are "standard claims" in the OIDC spec, not required. Fixing this
+  unblocks Entra and makes the library more correct for future providers. Docs-only
+  approach (B) leaves personal MS accounts unsupported and still surfaces deserialization
+  errors on misconfigured work accounts.
+
+### 2026-04-20: Excluded multi-tenant Entra support
+
+- Context: Entra supports `common` / `organizations` / `consumers` tenant endpoints for
+  multi-tenant apps, but the discovery document returns an issuer URL containing a
+  `{tenantid}` placeholder, which fails our strict issuer validation.
+- Decision: Single-tenant only for this issue. Document the limitation in `docs/entra.md`.
+- Reason: Multi-tenant issuer validation is non-trivial (pattern-match `{tenantid}` against
+  the actual tenant ID from the id_token) and is orthogonal to the Entra-specific work.
+  If demand appears, handle as a follow-up.
+
+### 2026-04-20: Kept `OAuth2Account.email` / `.name` required
+
+- Context: The fix could be propagated further by making `OAuth2Account.email` / `.name`
+  also `Option<String>`.
+- Decision: Keep them required. Error cleanly at the conversion step if both `email` and
+  `preferred_username` are absent.
+- Reason: DB schema and downstream UI code assume non-empty strings. Making the top-level
+  struct nullable would be a large ripple. The fallback in the conversion function is
+  sufficient for the realistic failure cases.
+
+## Resolution

--- a/.claude/issues/open/20260420-1456-add-line-provider.md
+++ b/.claude/issues/open/20260420-1456-add-line-provider.md
@@ -1,0 +1,115 @@
+# Issue: Add LINE Login as OAuth2 Provider
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-1456
+
+## Created: 2026-04-20-14-56
+
+## Closed:
+
+## Status: open
+
+## Priority: medium
+
+## Difficulty: medium
+
+## Description
+
+Add LINE Login v2.1 as a fifth optional OIDC provider alongside Google,
+Auth0, Keycloak, and Entra. LINE is OIDC-compliant and fits the established
+lock-step pattern with no architectural changes required.
+
+### Key LINE Login characteristics
+
+- **OIDC compliant** (v2.1 and later)
+- **Discovery URL**: `https://access.line.me/.well-known/openid-configuration`
+- **Issuer**: `https://access.line.me`
+- **Signing algorithm**: ES256 (already supported by `convert_jwk_to_decoding_key`)
+- **Scopes**: `openid`, `profile`, `email`
+
+### Caveats
+
+1. **`email` claim requires LINE approval**
+   - LINE Developer Console → "Email address permission" application required
+   - Before approval, `email` claim is not returned in tokens
+   - `preferred_username` is also typically absent → current fallback returns a
+     clean `OAuth2Error::Validation` at the conversion step
+
+2. **`name` is the LINE display name** — may contain emoji or spaces
+
+3. **`picture`** — LINE profile image URL
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: part of)
+- `20260420-0552` Add Entra Provider (relationship: same lock-step pattern, completed)
+
+## Approach
+
+Lock-step edits following the Entra pattern exactly. No new architectural work.
+
+### Implementation (6 lock-step edits in `provider.rs`)
+
+1. `Line` variant in `ProviderKind`
+2. Include in `ProviderKind::ALL`
+3. `as_str`: `Self::Line => "line"`
+4. `from_path_segment`: `"line" => Some(Self::Line)`
+5. `optional_env_contract`: trigger `OAUTH2_LINE_CLIENT_ID`, deps `OAUTH2_LINE_CLIENT_SECRET` + `OAUTH2_LINE_ISSUER_URL`
+6. `LINE_PROVIDER: LazyLock<Option<ProviderConfig>>` + `provider_for` arm
+
+### Env vars
+
+- `OAUTH2_LINE_CLIENT_ID` (trigger)
+- `OAUTH2_LINE_CLIENT_SECRET`
+- `OAUTH2_LINE_ISSUER_URL` = `https://access.line.me`
+- `OAUTH2_LINE_RESPONSE_MODE` (optional, default `form_post`)
+- `OAUTH2_LINE_SCOPE` (optional, default `openid+email+profile`)
+
+### UI
+
+- `provider_view` arm: `display_name: "LINE"`, `button_class: "btn-oauth2 btn-line"`
+- CSS: `--o2p-line: #06C755`, `--o2p-line-hover: #05A647`
+
+### Docs
+
+- `docs/src/guides/line.md` following Entra structure
+- Clear explanation of email approval requirement
+- Link to LINE Developers Console setup steps
+
+## Related Files
+
+- `oauth2_passkey/src/oauth2/provider.rs` — 6 lock-step edits
+- `oauth2_passkey/src/oauth2/provider/tests.rs` — 2 new tests
+- `oauth2_passkey_axum/src/oauth2.rs` — provider_view arm
+- `oauth2_passkey_axum/static/o2p-base.css` — CSS vars + button styles
+- `docs/src/guides/line.md` — new setup guide
+- `docs/src/SUMMARY.md` — add entry
+
+## Implementation Tasks
+
+- [ ] Add `Line` variant + 6 lock-step edits in `provider.rs`
+- [ ] Add 2 tests in `provider/tests.rs` (from_path_segment + optional_env_contract)
+- [ ] Add `"line"` arm in `provider_view`
+- [ ] Add CSS vars + `.btn-line` styles
+- [ ] Write `docs/src/guides/line.md`
+- [ ] Add entry to `docs/src/SUMMARY.md`
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] End-to-end: LINE login succeeds with approved app (email present)
+- [ ] Verify behavior with unapproved app (email absent) — clean error expected
+- [ ] Regression: Google / Auth0 / Keycloak / Entra login still work
+- [ ] Commit
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+## Resolution

--- a/.claude/issues/open/20260420-1457-add-apple-provider.md
+++ b/.claude/issues/open/20260420-1457-add-apple-provider.md
@@ -1,0 +1,184 @@
+# Issue: Add Sign in with Apple as OAuth2 Provider
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-1457
+
+## Created: 2026-04-20-14-57
+
+## Closed:
+
+## Status: open
+
+## Priority: low
+
+## Difficulty: large
+
+## Description
+
+Add Sign in with Apple as an optional OIDC provider. Apple is OIDC-compliant
+but requires a **dynamic JWT client_secret** generated from an ECDSA private
+key (P8 file), which is a significant architectural change compared to the
+static-secret providers (Google, Auth0, Keycloak, Entra, LINE).
+
+### Key Apple Sign In characteristics
+
+- **OIDC compliant**
+- **Discovery URL**: `https://appleid.apple.com/.well-known/openid-configuration`
+- **Issuer**: `https://appleid.apple.com`
+- **Signing algorithm**: ES256 / RS256
+- **`response_mode=form_post` required**
+
+### Blocker: Dynamic client_secret as JWT
+
+Unlike other providers where `client_secret` is a static string, Apple
+requires the client_secret to be a JWT signed with ES256 using a private
+key obtained from Apple Developer:
+
+```
+JWT header: { alg: "ES256", kid: "<key-id>" }
+JWT claims: {
+  iss: <team-id>,
+  sub: <client-id>,
+  aud: "https://appleid.apple.com",
+  exp: <now + N minutes (max 6 months)>,
+  iat: <now>
+}
+```
+
+The secret expires (max 6 months) and must be regenerated periodically.
+
+### Other Apple-specific behaviors
+
+1. **`name` and `email` only on first authorization**
+   - Apple only returns these claims the first time a user authorizes the app
+   - oauth2-passkey already persists email/name in DB on first login, so
+     subsequent logins reading from DB should work — but the initial
+     authorization response shape must be handled correctly
+   
+2. **Private email relay**
+   - User can choose "hide my email" → Apple returns `@privaterelay.appleid.com` proxy
+   - Valid email for storage purposes; no special handling needed
+   
+3. **HTTPS redirect required in production**
+   - localhost redirect not allowed in production app configuration
+   - Development setup requires workarounds
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: part of, replaces Phase 3)
+- `20260420-0552` Add Entra Provider (relationship: same lock-step pattern for the
+  parts that don't require the JWT secret)
+
+## Approach
+
+### Phase A: Client secret strategy abstraction
+
+Extend `ProviderConfig` to support runtime-generated secrets:
+
+```rust
+pub(crate) enum ClientSecret {
+    Static(String),
+    AppleJwt {
+        team_id: String,
+        key_id: String,
+        private_key_pem: String,  // P8 content
+    },
+}
+
+impl ClientSecret {
+    async fn resolve(&self) -> Result<String, OAuth2Error> {
+        match self {
+            Self::Static(s) => Ok(s.clone()),
+            Self::AppleJwt { .. } => generate_and_cache_apple_jwt(self).await,
+        }
+    }
+}
+```
+
+- Cache generated JWT for N minutes (e.g. 5 minutes) to avoid re-signing on every request
+- Token exchange site calls `ctx.client_secret.resolve().await?`
+
+### Phase B: P8 private key loading
+
+- Env vars:
+  - `OAUTH2_APPLE_CLIENT_ID` (trigger)
+  - `OAUTH2_APPLE_TEAM_ID`
+  - `OAUTH2_APPLE_KEY_ID`
+  - `OAUTH2_APPLE_PRIVATE_KEY_PATH` or `OAUTH2_APPLE_PRIVATE_KEY_PEM` (choose one)
+  - `OAUTH2_APPLE_ISSUER_URL = https://appleid.apple.com`
+  - `OAUTH2_APPLE_RESPONSE_MODE` (force `form_post`)
+- P8 file parse: use `jsonwebtoken` crate's `EncodingKey::from_ec_pem` (already in Cargo.toml)
+
+### Phase C: Lock-step provider edits
+
+Standard 6 edits in `provider.rs` (same pattern as Entra) plus:
+- `optional_env_contract` needs to account for team_id/key_id/private_key deps
+- `provider_for` arm wires up the `ClientSecret::AppleJwt` variant
+
+### Phase D: UI + docs
+
+- `provider_view` arm: `display_name: "Apple"`, `button_class: "btn-oauth2 btn-apple"`
+- CSS: black background, white Apple logo (Apple's brand guidelines strict)
+- `docs/src/guides/apple.md`:
+  - Apple Developer Portal walk-through (App ID, Service ID, Key)
+  - P8 file download + secure storage guidance
+  - Private email relay explanation
+  - Secret rotation reminder (6-month max)
+
+## Related Files
+
+- `oauth2_passkey/src/oauth2/provider.rs` — 6 lock-step edits + `ClientSecret` enum
+- `oauth2_passkey/src/oauth2/provider/tests.rs` — new tests including JWT generation
+- `oauth2_passkey/src/oauth2/main/oidc.rs` — token exchange site uses `ctx.client_secret.resolve()`
+- `oauth2_passkey/src/oauth2/main/apple.rs` — new module for Apple JWT generation/caching
+- `oauth2_passkey_axum/src/oauth2.rs` — provider_view arm
+- `oauth2_passkey_axum/static/o2p-base.css` — Apple-brand-compliant button styles
+- `docs/src/guides/apple.md` — new setup guide
+
+## Implementation Tasks
+
+### Phase A: Client secret strategy abstraction
+- [ ] Introduce `ClientSecret` enum with `Static` and `AppleJwt` variants
+- [ ] Add `resolve()` method with caching
+- [ ] Update `exchange_code_for_token` to call `ctx.client_secret.resolve().await?`
+- [ ] Update all existing providers to use `ClientSecret::Static(...)` (no behavior change)
+- [ ] Add unit tests for `ClientSecret::Static::resolve()`
+
+### Phase B: P8 private key loading + JWT generation
+- [ ] Implement `generate_apple_jwt` using `jsonwebtoken::encode` with ES256
+- [ ] Add JWT cache (5-minute TTL) keyed by team_id/key_id
+- [ ] Error handling for P8 parse failures, missing env vars
+- [ ] Unit tests with synthetic P8 keys
+
+### Phase C: Provider lock-step edits
+- [ ] Add `Apple` variant + 6 lock-step edits in `provider.rs`
+- [ ] Extend `optional_env_contract` for multi-dep (team_id, key_id, private_key)
+- [ ] Add 3+ tests in `provider/tests.rs`
+
+### Phase D: UI and docs
+- [ ] Add `"apple"` arm in `provider_view`
+- [ ] Add CSS vars + `.btn-apple` styles (Apple brand compliance)
+- [ ] Write `docs/src/guides/apple.md` (Apple Developer Portal setup)
+- [ ] Add entry to `docs/src/SUMMARY.md`
+
+### Verification
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] End-to-end: Apple login succeeds, DB row has `provider = "apple"`
+- [ ] Private relay email test: `@privaterelay.appleid.com` accepted and stored
+- [ ] Regression: all other providers still work
+- [ ] Commit
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+## Resolution

--- a/.claude/issues/open/20260420-1458-add-github-provider.md
+++ b/.claude/issues/open/20260420-1458-add-github-provider.md
@@ -1,0 +1,192 @@
+# Issue: Add GitHub as OAuth2 Provider (non-OIDC)
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-1458
+
+## Created: 2026-04-20-14-58
+
+## Closed:
+
+## Status: open
+
+## Priority: low
+
+## Difficulty: large
+
+## Description
+
+Add GitHub as an OAuth2 provider. Unlike the currently-supported providers
+(Google, Auth0, Keycloak, Entra), **GitHub does not implement OpenID Connect
+for end-user login**. This requires the first architectural change since the
+provider system was introduced: supporting a non-OIDC flow alongside the
+existing OIDC flow.
+
+### Why GitHub is not OIDC
+
+- No `/.well-known/openid-configuration` discovery endpoint for user login
+  - (GitHub Actions has an OIDC issuer for workflow federation, but that is
+    not usable for Sign-In-with-GitHub)
+- No ID token (JWT) issued
+- No JWKS endpoint
+- Identity info must be fetched from REST endpoints:
+  - `https://api.github.com/user` — profile data
+  - `https://api.github.com/user/emails` — email list (may be required if the
+    primary email is private)
+
+### Data shape mismatch with OIDC standard
+
+| OIDC claim | GitHub equivalent |
+|------------|-------------------|
+| `sub: String` | `id: u64` (numeric ID) |
+| `email: String` | `email` (may be null) |
+| `name: String` | `name` (display name, may be null) |
+| `preferred_username` | `login` (GitHub username) |
+| `picture` | `avatar_url` |
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: part of, replaces Phase 2)
+- `20260420-0552` Add Entra Provider (relationship: same provider-registration pattern,
+  different flow path)
+
+## Approach
+
+### Phase A: Flow abstraction
+
+Introduce a flow-type distinction at the `ProviderConfig` level:
+
+```rust
+pub(crate) enum ProviderFlow {
+    Oidc,         // existing path: discovery + id_token + userinfo
+    OAuth2Only,   // new path: no discovery, no id_token, REST userinfo
+}
+```
+
+Or alternatively, promote to a trait if the paths diverge significantly:
+
+```rust
+#[async_trait]
+pub(crate) trait AuthFlow {
+    async fn exchange_code(&self, code: String, verifier: String) -> Result<TokenResponse, OAuth2Error>;
+    async fn fetch_account(&self, tokens: &TokenResponse) -> Result<OAuth2Account, OAuth2Error>;
+}
+```
+
+The enum approach is simpler if the non-OIDC path is "GitHub only" for now;
+the trait approach is better if we anticipate more non-OIDC providers
+(e.g. Twitter, Discord) later.
+
+### Phase B: GitHub-specific flow
+
+Bypass the existing OIDC machinery entirely for GitHub:
+
+1. **Auth URL**: `https://github.com/login/oauth/authorize`
+2. **Token exchange**: `POST https://github.com/login/oauth/access_token`
+   - Request `Accept: application/json` to get JSON response instead of
+     form-urlencoded default
+3. **Profile fetch**: `GET https://api.github.com/user` with `Authorization: Bearer <token>`
+4. **Email fetch** (if `email` is null in profile): `GET https://api.github.com/user/emails`
+   - Find the entry with `"primary": true, "verified": true`
+5. **Build `OAuth2Account`**:
+   - `provider_user_id`: `format!("github_{}", user.id)`
+   - `email`: from step 3 or fallback to step 4; error if none verified
+   - `name`: `user.name` or `user.login` as fallback
+   - `picture`: `user.avatar_url`
+
+### Phase C: Security considerations
+
+- **No nonce validation** — GitHub OAuth2 doesn't issue id_token
+- **No at_hash verification** — same reason
+- **State CSRF protection** — still required (use existing state machinery)
+- **PKCE** — GitHub supports PKCE since 2022-04 (recommended)
+- **Email verification** — only accept `verified: true` emails from `/user/emails`
+  (a user can add an unverified email; do not use it as identity)
+
+### Phase D: Lock-step provider edits
+
+Standard provider registration (minus OIDC-specific env vars):
+
+- `ProviderKind::GitHub` variant
+- `optional_env_contract`:
+  - Trigger: `OAUTH2_GITHUB_CLIENT_ID`
+  - Deps: `OAUTH2_GITHUB_CLIENT_SECRET` only (no `_ISSUER_URL` — no discovery)
+- `GITHUB_PROVIDER: LazyLock<Option<ProviderConfig>>` with `flow: ProviderFlow::OAuth2Only`
+
+### Phase E: UI and docs
+
+- `provider_view` arm: `display_name: "GitHub"`, `button_class: "btn-oauth2 btn-github"`
+- CSS: GitHub black (`#24292e`) / white
+- `docs/src/guides/github.md`:
+  - OAuth App registration (github.com/settings/developers)
+  - `user:email` scope requirement
+  - Private email fallback explanation
+  - Comparison table "why GitHub is treated differently"
+
+## Related Files
+
+- `oauth2_passkey/src/oauth2/provider.rs` — add `ProviderFlow` enum + GitHub variant
+- `oauth2_passkey/src/oauth2/main/mod.rs` — dispatch to OIDC or GitHub flow
+- `oauth2_passkey/src/oauth2/main/github.rs` — new module (auth URL, token exchange, user fetch)
+- `oauth2_passkey/src/oauth2/types.rs` — `GitHubUser` struct + conversion to `OAuth2Account`
+- `oauth2_passkey/src/coordination/oauth2.rs` — dispatch based on `ProviderFlow`
+- `oauth2_passkey_axum/src/oauth2.rs` — provider_view arm
+- `oauth2_passkey_axum/static/o2p-base.css` — GitHub button styles
+- `docs/src/guides/github.md` — new setup guide
+
+## Implementation Tasks
+
+### Phase A: Flow abstraction
+- [ ] Decide: enum `ProviderFlow` vs trait `AuthFlow` (revisit after prototype)
+- [ ] Add `ProviderFlow` enum (or trait) to `provider.rs`
+- [ ] Update `ProviderConfig` to carry the flow type
+- [ ] Update coordination dispatch to branch on flow type
+- [ ] Update existing providers to use `ProviderFlow::Oidc` (no behavior change)
+- [ ] Verify existing tests still pass
+
+### Phase B: GitHub flow implementation
+- [ ] Create `oauth2/main/github.rs` module
+- [ ] Implement GitHub auth URL builder
+- [ ] Implement token exchange with `Accept: application/json`
+- [ ] Implement `/user` fetch + `GitHubUser` struct
+- [ ] Implement `/user/emails` fallback for private emails
+- [ ] Implement `GitHubUser -> OAuth2Account` conversion
+- [ ] Unit tests with mocked HTTP responses
+
+### Phase C: Security
+- [ ] Verify state CSRF protection works for GitHub flow
+- [ ] Implement PKCE for GitHub (S256)
+- [ ] Reject unverified emails from `/user/emails`
+- [ ] Document absence of nonce/at_hash in security docs
+
+### Phase D: Provider registration
+- [ ] Add `GitHub` variant + lock-step edits in `provider.rs`
+- [ ] Adapt `optional_env_contract` for GitHub's env-var shape (no ISSUER_URL)
+- [ ] Add tests in `provider/tests.rs`
+
+### Phase E: UI and docs
+- [ ] Add `"github"` arm in `provider_view`
+- [ ] Add CSS vars + `.btn-github` styles
+- [ ] Write `docs/src/guides/github.md`
+- [ ] Add entry to `docs/src/SUMMARY.md`
+
+### Verification
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] End-to-end: GitHub login (public email) succeeds, DB row has `provider = "github"`
+- [ ] End-to-end: GitHub login (private email) succeeds via `/user/emails` fallback
+- [ ] Regression: all OIDC providers still work
+- [ ] Commit
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+## Resolution

--- a/.claude/issues/open/20260420-1511-add-generic-oidc-provider.md
+++ b/.claude/issues/open/20260420-1511-add-generic-oidc-provider.md
@@ -1,0 +1,229 @@
+# Issue: Add Generic OIDC Provider Slots
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-1511
+
+## Created: 2026-04-20-15-11
+
+## Closed:
+
+## Status: open
+
+## Priority: high
+
+## Difficulty: medium
+
+## Description
+
+Introduce generic "Custom OIDC" provider slots so users can enable any
+standards-compliant OIDC provider via environment configuration alone, without
+needing a code change or library fork. This expands supported providers from
+a fixed list to "any OIDC-compliant IdP" with a single implementation effort.
+
+### Motivation
+
+Since Keycloak (`20260420-0307`) and Entra (`20260420-0552`) landed, the
+OIDC code path has been validated against three distinct providers
+(Google, Auth0, Keycloak, Entra). Empirically, any standards-compliant OIDC
+provider works with the existing flow given only:
+
+- `client_id`
+- `client_secret`
+- `issuer_url` (used for discovery)
+
+Providers that would be unlocked by generic OIDC slots without any new
+per-provider code:
+
+- **Okta** (enterprise SSO; free Developer Account for testing)
+- **AWS Cognito** (50,000 MAU free tier)
+- **Zitadel** (OSS IAM; cloud free tier or self-host)
+- **Ory Hydra** (OSS OIDC provider, self-host)
+- **Dex** (OSS OIDC provider that federates other IdPs)
+- **Authelia** (OSS SSO/2FA, self-host)
+- **Salesforce** (Developer Edition free)
+- **GitLab** (gitlab.com free or self-host)
+- **Microsoft Entra External ID** (was Azure AD B2C)
+- (and any future OIDC provider)
+
+### Design constraint
+
+Preserve the 2026-04-16 decision: **no HashMap-based `ProviderRegistry`**.
+The provider set must remain code-defined with `match` exhaustiveness
+enforcement. This means the generic slots are implemented as a fixed-count
+set of enum variants (e.g. `Custom1`..`Custom4`), not a dynamic registry.
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: part of)
+- `20260420-0552` Add Entra Provider (relationship: validates the OIDC code
+  path that generic slots reuse)
+
+## Approach
+
+### Enum extension
+
+```rust
+pub(crate) enum ProviderKind {
+    Google,
+    Auth0,
+    Keycloak,
+    Entra,
+    Custom(CustomSlot),
+}
+
+pub(crate) enum CustomSlot { Slot1, Slot2, Slot3, Slot4 }
+```
+
+- Named variants retain their specialised behavior (Google's FedCM hook, etc.)
+- `Custom(_)` variants use the shared OIDC code path with env-driven config
+
+### Slot env-var shape
+
+Per slot (using `CUSTOM1` as example):
+
+```bash
+OAUTH2_CUSTOM1_CLIENT_ID='...'              # trigger
+OAUTH2_CUSTOM1_CLIENT_SECRET='...'
+OAUTH2_CUSTOM1_ISSUER_URL='https://...'
+OAUTH2_CUSTOM1_DISPLAY_NAME='My SSO'        # UI button label
+OAUTH2_CUSTOM1_PATH_SEGMENT='my-sso'        # URL path (must be unique, [a-z0-9_-]+)
+OAUTH2_CUSTOM1_BUTTON_COLOR='#4A90E2'       # optional, default neutral gray
+OAUTH2_CUSTOM1_BUTTON_HOVER_COLOR='#357ABD' # optional, derived from button_color if absent
+OAUTH2_CUSTOM1_RESPONSE_MODE='form_post'    # optional, default form_post
+OAUTH2_CUSTOM1_SCOPE='openid+email+profile' # optional, default
+```
+
+Validation at startup (`optional_env_contract`-style):
+- If `_CLIENT_ID` is set, all of `_CLIENT_SECRET`, `_ISSUER_URL`,
+  `_DISPLAY_NAME`, `_PATH_SEGMENT` must be set
+- `_PATH_SEGMENT` must match `[a-z0-9_-]+` and not collide with named
+  providers (`google`, `auth0`, `keycloak`, `entra`, `authorized`, `accounts`,
+  `fedcm`, `popup_close`, `oauth2.js`) or other enabled slots
+
+### Path segment mapping
+
+`ProviderKind::from_path_segment` now returns `Some(ProviderKind::Custom(slot))`
+if the segment matches one of the configured custom slot path segments.
+Collision detection happens at `LazyLock` init; duplicates cause startup panic.
+
+### `provider_view` handling
+
+`display_name` and `button_class` must come from the `ProviderConfig` instead
+of being hardcoded in the axum crate:
+
+```rust
+pub(crate) struct ProviderConfig {
+    // ... existing fields
+    pub(crate) display_name: &'static str,   // or String for custom slots
+    pub(crate) button_class: &'static str,   // or String for custom slots
+}
+```
+
+For named providers, `display_name` / `button_class` are compile-time constants.
+For custom slots, they come from env vars.
+
+### CSS generation
+
+Two approaches:
+
+**Approach A (recommended)**: emit an inline `<style>` tag in the login
+template with the custom-slot button colors. No CSS file modification needed;
+colors flow from env to runtime CSS.
+
+**Approach B**: generate `.btn-custom1` ... `.btn-custom4` classes in
+`o2p-base.css` with CSS variables, and update variables at runtime via
+`style="--o2p-custom1: #...;"` on the button element.
+
+Approach A is simpler and keeps the CSS file static.
+
+### Scope: not included in this issue
+
+- **Non-OIDC providers** (GitHub) — handled separately in `20260420-1458`
+- **Dynamic secret** (Apple) — handled separately in `20260420-1457`
+- **Slot count** — fixed at 4 for now; revisit if demand for more appears
+- **FedCM** — generic slots do not participate in FedCM (Google-only)
+
+## Related Files
+
+- `oauth2_passkey/src/oauth2/provider.rs` — add `CustomSlot` enum + 4 LazyLock statics
+- `oauth2_passkey/src/oauth2/provider/tests.rs` — tests for slot env validation + collision
+- `oauth2_passkey_axum/src/oauth2.rs` — `provider_view` reads display_name from config
+- `oauth2_passkey_axum/src/templates/` — login template emits inline CSS for custom slots
+- `dot.env.example` — document `OAUTH2_CUSTOM1_*` env vars
+- `docs/src/guides/generic-oidc.md` — new setup guide with tested IdP list
+
+## Implementation Tasks
+
+### Core implementation
+- [ ] Add `CustomSlot` enum + `Custom(CustomSlot)` variant to `ProviderKind`
+- [ ] Add 4 `LazyLock<Option<ProviderConfig>>` statics (CUSTOM1..CUSTOM4)
+- [ ] Extend `ProviderConfig` with `display_name` / `button_class` / `button_color` / `button_hover_color`
+- [ ] Extend `optional_env_contract` to validate custom slot env shape
+- [ ] Path segment collision detection at LazyLock init
+- [ ] `from_path_segment` resolves custom slot path segments dynamically
+- [ ] `provider_for` arm for `Custom(slot)`
+
+### UI
+- [ ] `provider_view` reads `display_name` / `button_class` from config
+- [ ] Inline CSS generation for custom slot button colors in login template
+- [ ] Verify UI button renders correctly for a custom slot
+
+### Tests
+- [ ] Test: custom slot env validation (trigger + deps)
+- [ ] Test: path segment collision detection
+- [ ] Test: invalid path segment characters rejected
+- [ ] Test: slot falls back to defaults when optional env absent
+- [ ] Regression: all named providers still work
+
+### Docs
+- [ ] Update `dot.env.example` with `OAUTH2_CUSTOM1_*` block
+- [ ] Write `docs/src/guides/generic-oidc.md`:
+  - List of tested OIDC providers (Okta, AWS Cognito, Zitadel, Ory Hydra, Dex, Authelia, Salesforce, GitLab)
+  - Per-provider setup hints (issuer URL, scope quirks)
+  - Troubleshooting (most issuer-mismatch / JWKS issues already surfaced)
+- [ ] Add entry to `docs/src/SUMMARY.md`
+
+### Verification (pick 2-3 providers to end-to-end test)
+- [ ] Okta Developer Account login succeeds (free dev tenant)
+- [ ] Zitadel or Ory Hydra self-host login succeeds (Docker)
+- [ ] AWS Cognito login succeeds (free tier)
+- [ ] Verify named providers (Google/Auth0/Keycloak/Entra) untouched
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+### 2026-04-20: Fixed-slot design over HashMap registry
+
+- Context: Adding arbitrary OIDC providers could be done via a dynamic
+  `HashMap<String, ProviderConfig>` registry keyed on slot name. This was
+  deliberately rejected in 2026-04-16 for the named-provider design.
+- Decision: Use a fixed `CustomSlot` enum with 4 variants. Users can
+  enable 0-4 custom OIDC providers at a time.
+- Reason: Preserves `match` exhaustiveness at compile time. Avoids runtime
+  init lifecycle for a registry. 4 slots is empirically enough for most
+  deployments (named providers take the most common cases already).
+  Revisit if multiple users report hitting the cap.
+
+### 2026-04-20: Non-OIDC and dynamic-secret providers kept separate
+
+- Context: Generic OIDC slots could be extended to cover GitHub (non-OIDC)
+  and Apple (dynamic JWT secret) by adding per-slot flow-type and
+  secret-strategy fields.
+- Decision: Keep this issue scoped to OIDC-only with static secrets.
+  GitHub and Apple remain separate issues.
+- Reason: The value of generic slots is that they are a trivial extension
+  of the existing OIDC path. Mixing in non-OIDC and dynamic-secret variants
+  would reintroduce all the architectural complexity those issues are
+  designed to handle carefully. Independent issues keep scope clean.
+
+## Resolution

--- a/.claude/issues/open/20260420-1521-remove-oauth2-google-user-dead-code.md
+++ b/.claude/issues/open/20260420-1521-remove-oauth2-google-user-dead-code.md
@@ -1,0 +1,139 @@
+# Issue: Remove `OAUTH2_GOOGLE_USER` Dead Code and `oauth2_account_from_userinfo`
+
+## Table of Contents
+
+- [Description](#description)
+- [Related Issues](#related-issues)
+- [Approach](#approach)
+- [Related Files](#related-files)
+- [Implementation Tasks](#implementation-tasks)
+- [Decision Log](#decision-log)
+- [Resolution](#resolution)
+
+## ID: 20260420-1521
+
+## Created: 2026-04-20-15-21
+
+## Closed:
+
+## Status: open
+
+## Priority: low
+
+## Difficulty: small
+
+## Description
+
+`coordination/oauth2.rs` contains a `match` on a hardcoded `static` constant
+that makes two of its three arms unreachable, and a companion function
+(`oauth2_account_from_userinfo`) that is never called. This is leftover
+scaffolding from when userinfo-vs-idinfo was configurable and should be
+removed.
+
+### Current state (`coordination/oauth2.rs:260-267`)
+
+```rust
+// Convert IdInfo or UserInfo to OAuth2Account using the active provider name
+static OAUTH2_GOOGLE_USER: &str = "idinfo";
+
+let oauth2_account = match OAUTH2_GOOGLE_USER {
+    "idinfo" => oauth2_account_from_idinfo(&idinfo, provider_name)?,
+    "userinfo" => oauth2_account_from_userinfo(&userinfo, provider_name)?,
+    _ => oauth2_account_from_idinfo(&idinfo, provider_name)?, // Default case
+};
+```
+
+- `OAUTH2_GOOGLE_USER` is a `static &str` hardcoded to `"idinfo"`
+- Only the first arm is ever executed
+- `oauth2_account_from_userinfo` has no live callers in the binary
+
+### What stays
+
+- `fetch_userinfo` in `oauth2/main/core.rs` stays — the returned `userinfo`
+  is used for the `idinfo.sub == userinfo.sub` consistency check, which is
+  a useful defense-in-depth signal
+- `OidcUserInfo` struct stays for the same reason
+
+### Independence from GitHub (non-OIDC) issue
+
+GitHub (`20260420-1458`) would introduce a separate `OAuth2Only` flow that
+does not go through this code path (no id_token at all). So removing this
+dead code today does not conflict with the GitHub issue — they are on
+independent paths.
+
+## Related Issues
+
+- `20260226-2020` Expand OAuth2 Provider Support (relationship: cleanup surfaced during)
+- `20260420-0552` Add Entra Provider (relationship: the OIDC type relaxation work made
+  this dead code more visible)
+- `20260420-1458` Add GitHub Provider (relationship: independent — non-OIDC uses a different flow)
+
+## Approach
+
+### Step 1: Simplify the call site
+
+`coordination/oauth2.rs:260-267` becomes:
+
+```rust
+let oauth2_account = oauth2_account_from_idinfo(&idinfo, provider_name)?;
+```
+
+The `userinfo` returned from `get_idinfo_userinfo` is still used by the
+`idinfo.sub == userinfo.sub` check inside `get_idinfo_userinfo` itself, so
+the return shape of `get_idinfo_userinfo` does not need to change.
+
+### Step 2: Remove the dead function
+
+Delete `oauth2_account_from_userinfo` from `oauth2/types.rs`. Remove any
+`pub(crate)` / `use` references.
+
+### Step 3: Trim tests
+
+Remove `oauth2_account_from_userinfo` tests from `oauth2/types/tests.rs`
+(the fallback / error-path tests added during the Entra work that exercise
+only this function).
+
+The idinfo counterparts already have parallel tests, so coverage of the
+fallback logic is preserved.
+
+### Step 4: Verify
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features
+cargo test
+```
+
+Regression check: Google / Auth0 / Keycloak / Entra login still work.
+
+## Related Files
+
+- `oauth2_passkey/src/coordination/oauth2.rs` — remove `OAUTH2_GOOGLE_USER` + match
+- `oauth2_passkey/src/oauth2/types.rs` — remove `oauth2_account_from_userinfo`
+- `oauth2_passkey/src/oauth2/types/tests.rs` — remove related tests
+- (no changes) `oauth2_passkey/src/oauth2/main/core.rs` — `get_idinfo_userinfo` keeps fetching userinfo for sub-consistency
+
+## Implementation Tasks
+
+- [ ] Simplify the match to a single call in `coordination/oauth2.rs`
+- [ ] Delete `oauth2_account_from_userinfo` from `oauth2/types.rs`
+- [ ] Remove the corresponding tests from `oauth2/types/tests.rs`
+- [ ] Verify `cargo fmt --all` + `cargo clippy --all-targets --all-features` + `cargo test` clean
+- [ ] Regression: Google / Auth0 / Keycloak / Entra login still work
+- [ ] Commit
+
+## Decision Log
+
+<!-- APPEND-ONLY: Do not edit or delete existing entries. Add new entries at the bottom. -->
+
+### 2026-04-20: Keep `fetch_userinfo` and sub-consistency check
+
+- Context: With `oauth2_account_from_userinfo` removed, one could argue that
+  fetching userinfo at all is wasted work.
+- Decision: Keep `fetch_userinfo` and the `idinfo.sub == userinfo.sub` check.
+- Reason: The sub-consistency check is defense-in-depth — it catches id_token
+  / userinfo divergence that could signal a compromised provider or a proxy
+  attack. Cheap extra HTTPS call, real security value. Removing it is a
+  separate decision that would require its own issue.
+
+## Resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to oauth2-passkey will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1-dev]
+
+### Changed
+
+- **Breaking**: `OidcIdInfo.email` and `OidcIdInfo.name` are now `Option<String>`
+  (previously `String`) to comply with OIDC Core 1.0, which classifies them as
+  standard — not required — claims. Required for Microsoft Entra and other
+  providers that may omit these claims.
+  - Added `OidcIdInfo.preferred_username: Option<String>` as a documented
+    fallback for `email` (used by Microsoft personal accounts).
+  - `OAuth2Account.email` / `.name` remain non-optional; the conversion layer
+    uses `preferred_username` or errors with `OAuth2Error::Validation` if no
+    email claim is available.
+
 ## [0.5.0] - 2026-03-23
 
 ### Added

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,6 +44,7 @@
 - [Development Tunneling](guides/tunneling.md)
 - [Auth0 Provider Setup](guides/auth0.md)
 - [Keycloak Provider Setup](guides/keycloak.md)
+- [Microsoft Entra ID Provider Setup](guides/entra.md)
 
 ---
 

--- a/docs/src/guides/entra.md
+++ b/docs/src/guides/entra.md
@@ -1,0 +1,127 @@
+# Microsoft Entra ID Provider Setup
+
+This guide walks through configuring Microsoft Entra ID (formerly Azure Active Directory)
+as an OAuth2/OIDC provider for oauth2-passkey.
+
+## Prerequisites
+
+- A Microsoft Azure account with an active subscription (free tier works)
+- A running oauth2-passkey application
+
+> **Single-tenant only**: This guide covers single-tenant app registrations.
+> Multi-tenant endpoints (`common`, `organizations`) are not supported because
+> the discovery document returns a `{tenantid}` placeholder that fails the
+> library's issuer validation.
+
+## Step 1: Register an Application
+
+1. Go to the [Azure Portal](https://portal.azure.com/) and navigate to
+   **Microsoft Entra ID → App registrations → New registration**
+2. Set:
+   - **Name**: `oauth2-passkey-demo` (or any name)
+   - **Supported account types**: **Accounts in this organizational directory only
+     (Single tenant)**
+3. Leave **Redirect URI** blank for now
+4. Click **Register**
+
+After registration, note your:
+- **Application (client) ID** — this is `OAUTH2_ENTRA_CLIENT_ID`
+- **Directory (tenant) ID** — used to build `OAUTH2_ENTRA_ISSUER_URL`
+
+## Step 2: Set the Redirect URI
+
+1. On the app's overview page, click **Add a Redirect URI** (or go to
+   **Authentication → Add a platform → Web**)
+2. Enter: `http://localhost:3001/o2p/oauth2/entra/authorized`
+3. Replace `http://localhost:3001` with your actual `ORIGIN`
+4. Click **Configure**, then **Save**
+
+## Step 3: Create a Client Secret
+
+1. Navigate to **Certificates & secrets → Client secrets → New client secret**
+2. Enter a **Description** and choose an **Expiry** period
+3. Click **Add**
+4. **Copy the secret value immediately** — it will not be shown again
+
+This value is `OAUTH2_ENTRA_CLIENT_SECRET`.
+
+## Step 4: Enable the Email Claim (Work Accounts)
+
+By default, Entra ID does not include the `email` claim in tokens for some
+work/school accounts even when the `email` scope is requested. To ensure email
+is always available:
+
+1. Navigate to **Token configuration → Add optional claim**
+2. Select **Token type: ID** and check **email**
+3. Click **Add**
+
+> **Personal Microsoft accounts**: For personal accounts (e.g. `@outlook.com`,
+> `@hotmail.com`), the library automatically falls back to the `preferred_username`
+> claim when `email` is absent. No extra configuration is needed, but
+> `preferred_username` is used as the email value in the database.
+
+## Step 5: Configure Environment Variables
+
+Add the following to your `.env` file:
+
+```bash
+OAUTH2_ENTRA_CLIENT_ID='your-application-client-id'
+OAUTH2_ENTRA_CLIENT_SECRET='your-client-secret-value'
+# IMPORTANT: Must end with /v2.0 — the v1 endpoint (without /v2.0) uses a different
+# issuer format (sts.windows.net) that will cause issuer validation to fail.
+OAUTH2_ENTRA_ISSUER_URL='https://login.microsoftonline.com/your-tenant-id/v2.0'
+```
+
+Optional overrides (defaults shown):
+
+```bash
+# Default: 'form_post'
+#OAUTH2_ENTRA_RESPONSE_MODE='form_post'
+
+# Default: 'openid+email+profile'
+#OAUTH2_ENTRA_SCOPE='openid+email+profile'
+```
+
+## Step 6: Verify
+
+Start your application and navigate to the login page. A **Microsoft** button should
+appear alongside Google and other configured providers.
+
+After logging in, verify the database row:
+
+```bash
+# PostgreSQL
+psql $DATABASE_URL -c "SELECT provider, provider_user_id, email FROM o2p_oauth2_accounts ORDER BY created_at DESC LIMIT 3;"
+
+# SQLite
+sqlite3 db/sqlite/data/data.db "SELECT provider, provider_user_id, email FROM o2p_oauth2_accounts ORDER BY created_at DESC LIMIT 3;"
+```
+
+Expected output:
+
+```
+ provider |             provider_user_id              |       email
+----------+-------------------------------------------+--------------------
+ entra    | entra_00000000-0000-0000-0000-000000000000 | user@example.com
+```
+
+> A consent screen will appear on every login because `prompt=consent` is
+> included in the authorization request. This is expected behavior.
+
+## Notes
+
+- **Single-tenant only**: The `OAUTH2_ENTRA_ISSUER_URL` must contain a specific
+  tenant ID (e.g. `https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2.0`).
+  Using `common` or `organizations` as the tenant segment will cause issuer
+  validation to fail.
+
+- **Email claim fallback**: When the `email` claim is absent (e.g. personal
+  Microsoft accounts), the library uses `preferred_username` as the email value.
+  For work accounts, enable the `email` optional claim (Step 4) to ensure
+  consistent behavior.
+
+- **`provider_user_id` format**: `entra_{sub}` where `sub` is the Entra object ID
+  (a UUID) of the user. This is stable across sessions and unique within your tenant.
+
+- **Client secret expiry**: Azure client secrets expire (max 24 months). Rotate the
+  secret before expiry and update `OAUTH2_ENTRA_CLIENT_SECRET` in your environment.

--- a/docs/src/guides/entra.md
+++ b/docs/src/guides/entra.md
@@ -3,32 +3,48 @@
 This guide walks through configuring Microsoft Entra ID (formerly Azure Active Directory)
 as an OAuth2/OIDC provider for oauth2-passkey.
 
+## Which Setup to Choose
+
+| Use case | Account type | Section |
+|----------|--------------|---------|
+| B2C consumer web app (anyone with a Microsoft account can sign up) | Personal Microsoft accounts | [Personal Account Setup](#personal-microsoft-account-setup-b2c) |
+| B2B / internal tool (restrict to a specific organization) | Work/school accounts | [Work/School Account Setup](#workschool-account-setup-b2b) |
+
+> **Not supported**: A single app registration serving both personal and
+> work/school accounts (multi-tenant with `common` / `organizations` endpoints)
+> is **not supported**. See [Notes](#notes).
+
 ## Prerequisites
 
-- A Microsoft Azure account with an active subscription (free tier works)
+- A Microsoft Azure account (free tier works)
 - A running oauth2-passkey application
 
-> **Single-tenant only**: This guide covers single-tenant app registrations.
-> Multi-tenant endpoints (`common`, `organizations`) are not supported because
-> the discovery document returns a `{tenantid}` placeholder that fails the
-> library's issuer validation.
+---
 
-## Step 1: Register an Application
+## Personal Microsoft Account Setup (B2C)
+
+Use this path to let anyone with a personal Microsoft account
+(`@outlook.com`, `@hotmail.com`, `@live.com`, etc.) sign up for your app.
+
+> **Warning**: Anyone in the world with a Microsoft account will be able to
+> register. Azure does not provide email or domain allowlisting for personal
+> accounts because consumer accounts are not centrally managed. If you need
+> to restrict access, see [Restricting Access](#restricting-access) below.
+
+### Step 1: Register an Application
 
 1. Go to the [Azure Portal](https://portal.azure.com/) and navigate to
    **Microsoft Entra ID → App registrations → New registration**
 2. Set:
-   - **Name**: `oauth2-passkey-demo` (or any name)
-   - **Supported account types**: **Accounts in this organizational directory only
-     (Single tenant)**
+   - **Name**: `oauth2-passkey-demo-personal` (or any name)
+   - **Supported account types**: **Personal Microsoft accounts only**
 3. Leave **Redirect URI** blank for now
 4. Click **Register**
 
-After registration, note your:
-- **Application (client) ID** — this is `OAUTH2_ENTRA_CLIENT_ID`
-- **Directory (tenant) ID** — used to build `OAUTH2_ENTRA_ISSUER_URL`
+After registration, note your **Application (client) ID** — this is
+`OAUTH2_ENTRA_CLIENT_ID`.
 
-## Step 2: Set the Redirect URI
+### Step 2: Set the Redirect URI
 
 1. On the app's overview page, click **Add a Redirect URI** (or go to
    **Authentication → Add a platform → Web**)
@@ -36,7 +52,7 @@ After registration, note your:
 3. Replace `http://localhost:3001` with your actual `ORIGIN`
 4. Click **Configure**, then **Save**
 
-## Step 3: Create a Client Secret
+### Step 3: Create a Client Secret
 
 1. Navigate to **Certificates & secrets → Client secrets → New client secret**
 2. Enter a **Description** and choose an **Expiry** period
@@ -45,30 +61,137 @@ After registration, note your:
 
 This value is `OAUTH2_ENTRA_CLIENT_SECRET`.
 
-## Step 4: Enable the Email Claim (Work Accounts)
-
-By default, Entra ID does not include the `email` claim in tokens for some
-work/school accounts even when the `email` scope is requested. To ensure email
-is always available:
-
-1. Navigate to **Token configuration → Add optional claim**
-2. Select **Token type: ID** and check **email**
-3. Click **Add**
-
-> **Personal Microsoft accounts**: For personal accounts (e.g. `@outlook.com`,
-> `@hotmail.com`), the library automatically falls back to the `preferred_username`
-> claim when `email` is absent. No extra configuration is needed, but
-> `preferred_username` is used as the email value in the database.
-
-## Step 5: Configure Environment Variables
+### Step 4: Configure Environment Variables
 
 Add the following to your `.env` file:
 
 ```bash
 OAUTH2_ENTRA_CLIENT_ID='your-application-client-id'
 OAUTH2_ENTRA_CLIENT_SECRET='your-client-secret-value'
-# IMPORTANT: Must end with /v2.0 — the v1 endpoint (without /v2.0) uses a different
-# issuer format (sts.windows.net) that will cause issuer validation to fail.
+# Microsoft's fixed tenant ID for personal (consumer) accounts.
+# This UUID is NOT your tenant — it's a well-known constant.
+OAUTH2_ENTRA_ISSUER_URL='https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0'
+```
+
+> **Why this specific UUID?** The `consumers` endpoint alias
+> (`https://login.microsoftonline.com/consumers/v2.0`) returns a discovery
+> document whose `issuer` field is the fixed UUID above. Because
+> oauth2-passkey performs strict issuer validation, you must configure the
+> UUID directly — using the `consumers` alias will fail with an issuer
+> mismatch error.
+
+Optional overrides (defaults shown):
+
+```bash
+# Default: 'form_post'
+#OAUTH2_ENTRA_RESPONSE_MODE='form_post'
+
+# Default: 'openid+email+profile'
+#OAUTH2_ENTRA_SCOPE='openid+email+profile'
+```
+
+### Step 5: Verify
+
+Start your application and navigate to the login page. A **Microsoft** button
+should appear alongside Google and other configured providers.
+
+After logging in with a personal Microsoft account, verify the database row:
+
+```bash
+# PostgreSQL
+psql $DATABASE_URL -c "SELECT provider, provider_user_id, email FROM o2p_oauth2_accounts ORDER BY created_at DESC LIMIT 3;"
+
+# SQLite
+sqlite3 db/sqlite/data/data.db "SELECT provider, provider_user_id, email FROM o2p_oauth2_accounts ORDER BY created_at DESC LIMIT 3;"
+```
+
+Expected output:
+
+```
+ provider |             provider_user_id              |       email
+----------+-------------------------------------------+--------------------
+ entra    | entra_00000000-0000-0000-0000-000000000000 | user@outlook.com
+```
+
+For personal accounts, the `email` column is populated from the
+`preferred_username` claim because Microsoft does not issue a standard
+`email` claim for consumer accounts.
+
+### Restricting Access
+
+Since Azure cannot restrict which personal Microsoft accounts can sign up,
+access control is the application's responsibility. Two practical options:
+
+1. **Application-layer email allowlist** — After oauth2-passkey creates the
+   account, your handler/middleware checks the email against an allowlist
+   and rejects unknown addresses.
+
+2. **Admin approval flow** — oauth2-passkey's built-in behavior makes the
+   first registered user an admin. Let new users register, then review them
+   in your admin UI and delete unwanted accounts.
+
+---
+
+## Work/School Account Setup (B2B)
+
+Use this path to restrict login to users within a specific organization's
+Entra ID tenant.
+
+### Step 1: Register an Application
+
+1. Go to the [Azure Portal](https://portal.azure.com/) and navigate to
+   **Microsoft Entra ID → App registrations → New registration**
+2. Set:
+   - **Name**: `oauth2-passkey-demo` (or any name)
+   - **Supported account types**: **Accounts in this organizational directory
+     only (Single tenant)**
+3. Leave **Redirect URI** blank for now
+4. Click **Register**
+
+After registration, note your:
+- **Application (client) ID** — this is `OAUTH2_ENTRA_CLIENT_ID`
+- **Directory (tenant) ID** — used to build `OAUTH2_ENTRA_ISSUER_URL`
+
+### Step 2: Set the Redirect URI
+
+1. On the app's overview page, click **Add a Redirect URI** (or go to
+   **Authentication → Add a platform → Web**)
+2. Enter: `http://localhost:3001/o2p/oauth2/entra/authorized`
+3. Replace `http://localhost:3001` with your actual `ORIGIN`
+4. Click **Configure**, then **Save**
+
+### Step 3: Create a Client Secret
+
+1. Navigate to **Certificates & secrets → Client secrets → New client secret**
+2. Enter a **Description** and choose an **Expiry** period
+3. Click **Add**
+4. **Copy the secret value immediately** — it will not be shown again
+
+This value is `OAUTH2_ENTRA_CLIENT_SECRET`.
+
+### Step 4: Enable the Email Claim
+
+By default, Entra ID does not include the `email` claim in tokens for some
+work/school accounts even when the `email` scope is requested. To ensure
+email is always available:
+
+1. Navigate to **Token configuration → Add optional claim**
+2. Select **Token type: ID** and check **email**
+3. Click **Add**
+
+If `email` is still absent (e.g. the user has no email attribute set), the
+library falls back to the `preferred_username` claim (typically the UPN).
+
+### Step 5: Configure Environment Variables
+
+Add the following to your `.env` file:
+
+```bash
+OAUTH2_ENTRA_CLIENT_ID='your-application-client-id'
+OAUTH2_ENTRA_CLIENT_SECRET='your-client-secret-value'
+# IMPORTANT: Must end with /v2.0 — the v1 endpoint (without /v2.0) uses a
+# different issuer format (sts.windows.net) that will cause issuer
+# validation to fail.
 OAUTH2_ENTRA_ISSUER_URL='https://login.microsoftonline.com/your-tenant-id/v2.0'
 ```
 
@@ -82,10 +205,10 @@ Optional overrides (defaults shown):
 #OAUTH2_ENTRA_SCOPE='openid+email+profile'
 ```
 
-## Step 6: Verify
+### Step 6: Verify
 
-Start your application and navigate to the login page. A **Microsoft** button should
-appear alongside Google and other configured providers.
+Start your application and navigate to the login page. A **Microsoft** button
+should appear alongside Google and other configured providers.
 
 After logging in, verify the database row:
 
@@ -105,23 +228,30 @@ Expected output:
  entra    | entra_00000000-0000-0000-0000-000000000000 | user@example.com
 ```
 
-> A consent screen will appear on every login because `prompt=consent` is
-> included in the authorization request. This is expected behavior.
+---
 
 ## Notes
 
-- **Single-tenant only**: The `OAUTH2_ENTRA_ISSUER_URL` must contain a specific
-  tenant ID (e.g. `https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2.0`).
-  Using `common` or `organizations` as the tenant segment will cause issuer
-  validation to fail.
+- **Single-tenant only** (per app registration): The `OAUTH2_ENTRA_ISSUER_URL`
+  must resolve to a specific tenant — either your organization's tenant
+  (work/school) or Microsoft's fixed consumer tenant UUID (personal). Using
+  `common` or `organizations` aliases will fail issuer validation because
+  their discovery documents contain a `{tenantid}` placeholder.
 
-- **Email claim fallback**: When the `email` claim is absent (e.g. personal
-  Microsoft accounts), the library uses `preferred_username` as the email value.
-  For work accounts, enable the `email` optional claim (Step 4) to ensure
-  consistent behavior.
+- **Mixed (work + personal) not supported**: Supporting both account types
+  with one app registration requires multi-tenant issuer validation, which
+  is not implemented. The workaround is to register two separate
+  applications (one personal, one work/school) — however, oauth2-passkey
+  currently supports only one Entra provider instance per deployment.
 
-- **`provider_user_id` format**: `entra_{sub}` where `sub` is the Entra object ID
-  (a UUID) of the user. This is stable across sessions and unique within your tenant.
+- **Consent screen on every login**: A consent screen appears on every login
+  because `prompt=consent` is included in the authorization request. This
+  is expected behavior.
 
-- **Client secret expiry**: Azure client secrets expire (max 24 months). Rotate the
-  secret before expiry and update `OAUTH2_ENTRA_CLIENT_SECRET` in your environment.
+- **`provider_user_id` format**: `entra_{sub}` where `sub` is the Entra
+  object ID (a UUID) of the user. This is stable across sessions and
+  unique within the issuing tenant.
+
+- **Client secret expiry**: Azure client secrets expire (max 24 months).
+  Rotate the secret before expiry and update `OAUTH2_ENTRA_CLIENT_SECRET`
+  in your environment.

--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -261,9 +261,9 @@ async fn process_oauth2_authorization(
     static OAUTH2_GOOGLE_USER: &str = "idinfo";
 
     let oauth2_account = match OAUTH2_GOOGLE_USER {
-        "idinfo" => oauth2_account_from_idinfo(&idinfo, provider_name),
-        "userinfo" => oauth2_account_from_userinfo(&userinfo, provider_name),
-        _ => oauth2_account_from_idinfo(&idinfo, provider_name), // Default case
+        "idinfo" => oauth2_account_from_idinfo(&idinfo, provider_name)?,
+        "userinfo" => oauth2_account_from_userinfo(&userinfo, provider_name)?,
+        _ => oauth2_account_from_idinfo(&idinfo, provider_name)?, // Default case
     };
 
     // Extract user_id from the stored session if available
@@ -496,7 +496,7 @@ pub async fn fedcm_authorized_core(
     let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
 
     // 2. Build OAuth2Account from the verified ID token
-    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
+    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str())?;
 
     // 3. Parse mode directly from request (no cache round-trip needed for FedCM)
     let mode = match &request.mode {

--- a/oauth2_passkey/src/coordination/oauth2/tests.rs
+++ b/oauth2_passkey/src/coordination/oauth2/tests.rs
@@ -40,7 +40,7 @@ async fn fedcm_authorized_core_with_ctx(
     headers: &HeaderMap,
 ) -> Result<(HeaderMap, String), CoordinationError> {
     let idinfo = validate_fedcm_token(ctx, &request.credential, &request.nonce_id).await?;
-    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str());
+    let oauth2_account = oauth2_account_from_idinfo(&idinfo, ctx.kind.as_str())?;
 
     let mode = match &request.mode {
         Some(mode_str) => {

--- a/oauth2_passkey/src/oauth2/main/idtoken.rs
+++ b/oauth2_passkey/src/oauth2/main/idtoken.rs
@@ -20,7 +20,8 @@ struct Jwks {
 struct Jwk {
     kty: String,
     kid: String,
-    alg: String,
+    /// Optional: some providers (e.g. Entra) omit `alg`; fall back to kty-derived default.
+    alg: Option<String>,
     n: Option<String>,
     e: Option<String>,
     x: Option<String>,
@@ -37,10 +38,12 @@ pub struct OidcIdInfo {
     /// Google-specific; absent in many other OIDC providers (e.g. Auth0).
     pub azp: Option<String>,
     pub aud: String,
-    pub email: String,
+    /// Optional per OIDC Core 1.0; absent for some Microsoft personal accounts.
+    pub email: Option<String>,
     /// Some providers omit this claim; treat absence as unverified.
     pub email_verified: Option<bool>,
-    pub name: String,
+    /// Optional per OIDC Core 1.0; absent when profile scope not granted.
+    pub name: Option<String>,
     pub picture: Option<String>,
     /// Absent in many non-Google OIDC providers.
     pub given_name: Option<String>,
@@ -54,6 +57,9 @@ pub struct OidcIdInfo {
     pub nonce: Option<String>,
     pub hd: Option<String>,
     pub at_hash: Option<String>,
+    /// Fallback for `email` when the provider omits the standard claim
+    /// (e.g. Microsoft personal accounts).
+    pub preferred_username: Option<String>,
 }
 
 #[derive(Error, Debug)]
@@ -201,7 +207,15 @@ fn decode_base64_url_safe(input: &str) -> Result<Vec<u8>, TokenVerificationError
 }
 
 fn convert_jwk_to_decoding_key(jwk: &Jwk) -> Result<DecodingKey, TokenVerificationError> {
-    match jwk.alg.as_str() {
+    // When `alg` is absent, infer from `kty` (Entra and some other providers omit `alg`).
+    let alg_default = match jwk.kty.as_str() {
+        "RSA" => "RS256",
+        "EC" => "ES256",
+        "oct" => "HS256",
+        _ => "",
+    };
+    let alg = jwk.alg.as_deref().unwrap_or(alg_default);
+    match alg {
         "RS256" | "RS384" | "RS512" => {
             let n = jwk
                 .n

--- a/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
@@ -13,7 +13,7 @@ fn test_find_jwk_existing_key() {
             Jwk {
                 kty: "RSA".to_string(),
                 kid: "key1".to_string(),
-                alg: "RS256".to_string(),
+                alg: Some("RS256".to_string()),
                 n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
                 e: Some("AQAB".to_string()),
                 x: None,
@@ -24,7 +24,7 @@ fn test_find_jwk_existing_key() {
             Jwk {
                 kty: "RSA".to_string(),
                 kid: "key2".to_string(),
-                alg: "RS256".to_string(),
+                alg: Some("RS256".to_string()),
                 n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
                 e: Some("AQAB".to_string()),
                 x: None,
@@ -38,7 +38,7 @@ fn test_find_jwk_existing_key() {
     let result = find_jwk(&jwks, "key1");
     assert!(result.is_some());
     assert_eq!(result.unwrap().kid, "key1");
-    assert_eq!(result.unwrap().alg, "RS256");
+    assert_eq!(result.unwrap().alg, Some("RS256".to_string()));
 }
 
 /// Test finding a non-existing JWK in a JWK set
@@ -54,7 +54,7 @@ fn test_find_jwk_non_existing_key() {
             Jwk {
                 kty: "RSA".to_string(),
                 kid: "key1".to_string(),
-                alg: "RS256".to_string(),
+                alg: Some("RS256".to_string()),
                 n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
                 e: Some("AQAB".to_string()),
                 x: None,
@@ -153,7 +153,7 @@ fn test_convert_jwk_to_decoding_key_missing_n_component() {
     let jwk = Jwk {
         kty: "RSA".to_string(),
         kid: "test_key".to_string(),
-        alg: "RS256".to_string(),
+        alg: Some("RS256".to_string()),
         n: None, // Missing n component
         e: Some("AQAB".to_string()),
         x: None,
@@ -180,7 +180,7 @@ fn test_convert_jwk_to_decoding_key_missing_e_component() {
     let jwk = Jwk {
         kty: "RSA".to_string(),
         kid: "test_key".to_string(),
-        alg: "RS256".to_string(),
+        alg: Some("RS256".to_string()),
         n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
         e: None, // Missing e component
         x: None,
@@ -208,7 +208,7 @@ fn test_convert_jwk_to_decoding_key_missing_x_component_es256() {
     let jwk = Jwk {
         kty: "EC".to_string(),
         kid: "test_key".to_string(),
-        alg: "ES256".to_string(),
+        alg: Some("ES256".to_string()),
         n: None,
         e: None,
         x: None, // Missing x component
@@ -235,7 +235,7 @@ fn test_convert_jwk_to_decoding_key_missing_y_component_es256() {
     let jwk = Jwk {
         kty: "EC".to_string(),
         kid: "test_key".to_string(),
-        alg: "ES256".to_string(),
+        alg: Some("ES256".to_string()),
         n: None,
         e: None,
         x: Some("WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGHwHitJBcBmXw".to_string()),
@@ -262,7 +262,7 @@ fn test_convert_jwk_to_decoding_key_missing_k_component_hs256() {
     let jwk = Jwk {
         kty: "oct".to_string(),
         kid: "test_key".to_string(),
-        alg: "HS256".to_string(),
+        alg: Some("HS256".to_string()),
         n: None,
         e: None,
         x: None,
@@ -289,7 +289,7 @@ fn test_convert_jwk_to_decoding_key_unsupported_algorithm() {
     let jwk = Jwk {
         kty: "RSA".to_string(),
         kid: "test_key".to_string(),
-        alg: "UNSUPPORTED".to_string(),
+        alg: Some("UNSUPPORTED".to_string()),
         n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
         e: Some("AQAB".to_string()),
         x: None,
@@ -318,7 +318,7 @@ fn test_convert_jwk_to_decoding_key_hs256_valid() {
     let jwk = Jwk {
         kty: "oct".to_string(),
         kid: "test_key".to_string(),
-        alg: "HS256".to_string(),
+        alg: Some("HS256".to_string()),
         n: None,
         e: None,
         x: None,
@@ -428,9 +428,9 @@ fn test_decode_token_valid_payload() {
     let id_info = result.unwrap();
     assert_eq!(id_info.iss, "https://accounts.google.com");
     assert_eq!(id_info.sub, "123456789");
-    assert_eq!(id_info.email, "test@example.com");
+    assert_eq!(id_info.email, Some("test@example.com".to_string()));
     assert_eq!(id_info.email_verified, Some(true));
-    assert_eq!(id_info.name, "Test User");
+    assert_eq!(id_info.name, Some("Test User".to_string()));
 }
 
 /// Test signature verification with invalid token format
@@ -608,7 +608,7 @@ fn test_jwks_cache_conversion() {
             Jwk {
                 kty: "RSA".to_string(),
                 kid: "key1".to_string(),
-                alg: "RS256".to_string(),
+                alg: Some("RS256".to_string()),
                 n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
                 e: Some("AQAB".to_string()),
                 x: None,

--- a/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/idtoken/tests.rs
@@ -331,6 +331,33 @@ fn test_convert_jwk_to_decoding_key_hs256_valid() {
     assert!(result.is_ok());
 }
 
+/// Test JWK to decoding key conversion when `alg` is absent.
+///
+/// Some providers (notably Microsoft Entra) publish JWKS entries without
+/// the optional `alg` field. `convert_jwk_to_decoding_key` must infer the
+/// algorithm from `kty`: RSA -> RS256.
+///
+#[test]
+fn test_convert_jwk_to_decoding_key_alg_none_rsa_defaults_to_rs256() {
+    let jwk = Jwk {
+        kty: "RSA".to_string(),
+        kid: "test_key".to_string(),
+        alg: None, // Provider omitted `alg`; should default to RS256.
+        n: Some("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw".to_string()),
+        e: Some("AQAB".to_string()),
+        x: None,
+        y: None,
+        crv: None,
+        k: None,
+    };
+
+    let result = convert_jwk_to_decoding_key(&jwk);
+    assert!(
+        result.is_ok(),
+        "expected RSA with alg: None to succeed via RS256 default, got: {result:?}"
+    );
+}
+
 /// Test token decoding with too few parts
 ///
 /// This test verifies that `decode_token` returns InvalidTokenFormat error

--- a/oauth2_passkey/src/oauth2/main/oidc/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/oidc/tests.rs
@@ -31,8 +31,8 @@ fn test_oidc_userinfo_deserialization() {
         "Should successfully deserialize valid Google user info"
     );
     let user_info = user_info.expect("Already verified result is Ok");
-    assert_eq!(user_info.email, "test@example.com");
-    assert_eq!(user_info.name, "Test User");
+    assert_eq!(user_info.email, Some("test@example.com".to_string()));
+    assert_eq!(user_info.name, Some("Test User".to_string()));
 }
 
 /// Test successful deserialization of OIDC token response with id_token

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -27,11 +27,13 @@ pub(crate) enum ProviderKind {
     Google,
     Auth0,
     Keycloak,
+    Entra,
 }
 
 impl ProviderKind {
     /// All supported provider kinds in stable display order.
-    pub(crate) const ALL: &'static [Self] = &[Self::Google, Self::Auth0, Self::Keycloak];
+    pub(crate) const ALL: &'static [Self] =
+        &[Self::Google, Self::Auth0, Self::Keycloak, Self::Entra];
 
     /// Env-var validation contract for optional providers.
     ///
@@ -55,6 +57,10 @@ impl ProviderKind {
                     "OAUTH2_KEYCLOAK_ISSUER_URL",
                 ],
             )),
+            Self::Entra => Some((
+                "OAUTH2_ENTRA_CLIENT_ID",
+                &["OAUTH2_ENTRA_CLIENT_SECRET", "OAUTH2_ENTRA_ISSUER_URL"],
+            )),
         }
     }
 
@@ -63,6 +69,7 @@ impl ProviderKind {
             Self::Google => "google",
             Self::Auth0 => "auth0",
             Self::Keycloak => "keycloak",
+            Self::Entra => "entra",
         }
     }
 
@@ -73,6 +80,7 @@ impl ProviderKind {
             "google" => Some(Self::Google),
             "auth0" => Some(Self::Auth0),
             "keycloak" => Some(Self::Keycloak),
+            "entra" => Some(Self::Entra),
             _ => None,
         }
     }
@@ -288,6 +296,42 @@ pub(crate) static KEYCLOAK_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock
     })
 });
 
+/// Microsoft Entra ID provider — optional, enabled by setting `OAUTH2_ENTRA_CLIENT_ID`.
+/// Issuer URL format: `https://login.microsoftonline.com/{tenant_id}/v2.0` (single-tenant only).
+/// Multi-tenant endpoints (`common`, `organizations`) are not supported because the discovery
+/// document returns a `{tenantid}` placeholder that fails issuer validation.
+pub(crate) static ENTRA_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock::new(|| {
+    let client_id = env::var("OAUTH2_ENTRA_CLIENT_ID").ok()?;
+    let client_secret = env::var("OAUTH2_ENTRA_CLIENT_SECRET")
+        .expect("OAUTH2_ENTRA_CLIENT_ID set but OAUTH2_ENTRA_CLIENT_SECRET missing");
+    let issuer_url = env::var("OAUTH2_ENTRA_ISSUER_URL")
+        .expect("OAUTH2_ENTRA_CLIENT_ID set but OAUTH2_ENTRA_ISSUER_URL missing");
+    let origin = env::var("ORIGIN").expect("Missing ORIGIN!");
+    let redirect_uri = format!(
+        "{}{}/oauth2/entra/authorized",
+        origin,
+        O2P_ROUTE_PREFIX.as_str()
+    );
+    let response_mode =
+        env::var("OAUTH2_ENTRA_RESPONSE_MODE").unwrap_or_else(|_| "form_post".to_string());
+    let scope =
+        env::var("OAUTH2_ENTRA_SCOPE").unwrap_or_else(|_| "openid+email+profile".to_string());
+    let query_string = format!(
+        "&response_type=code&scope={}&response_mode={}&prompt=consent",
+        scope, response_mode
+    );
+    Some(ProviderConfig {
+        kind: ProviderKind::Entra,
+        client_id,
+        client_secret,
+        issuer_url,
+        redirect_uri,
+        response_mode,
+        query_string,
+        discovery: OnceLock::new(),
+    })
+});
+
 /// Resolve a `ProviderKind` to its `&'static ProviderConfig`.
 ///
 /// Returns `None` if the provider is optional and not configured (its env vars
@@ -297,6 +341,7 @@ pub(crate) fn provider_for(kind: ProviderKind) -> Option<&'static ProviderConfig
         ProviderKind::Google => Some(&GOOGLE_PROVIDER),
         ProviderKind::Auth0 => AUTH0_PROVIDER.as_ref(),
         ProviderKind::Keycloak => KEYCLOAK_PROVIDER.as_ref(),
+        ProviderKind::Entra => ENTRA_PROVIDER.as_ref(),
     }
 }
 

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -31,6 +31,16 @@ fn test_provider_kind_as_str() {
     assert_eq!(ProviderKind::Google.as_str(), "google");
 }
 
+// --- from_path_segment: entra ---
+
+#[test]
+fn test_provider_kind_from_path_segment_entra() {
+    assert_eq!(
+        ProviderKind::from_path_segment("entra"),
+        Some(ProviderKind::Entra)
+    );
+}
+
 // --- optional_env_contract ---
 
 #[test]

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -71,6 +71,16 @@ fn test_optional_env_contract_keycloak() {
     );
 }
 
+#[test]
+fn test_optional_env_contract_entra() {
+    let (trigger, required) = ProviderKind::Entra.optional_env_contract().unwrap();
+    assert_eq!(trigger, "OAUTH2_ENTRA_CLIENT_ID");
+    assert_eq!(
+        required,
+        ["OAUTH2_ENTRA_CLIENT_SECRET", "OAUTH2_ENTRA_ISSUER_URL"]
+    );
+}
+
 // --- provider_for ---
 
 #[test]

--- a/oauth2_passkey/src/oauth2/types.rs
+++ b/oauth2_passkey/src/oauth2/types.rs
@@ -61,18 +61,22 @@ impl Default for OAuth2Account {
 
 /// Userinfo endpoint response.
 ///
-/// All fields except `sub`, `name`, and `email` are optional because
-/// non-Google OIDC providers may omit them.
+/// `email` and `name` are optional per OIDC Core 1.0 (they are standard claims,
+/// not required ones).  When `email` is absent the implementation falls back to
+/// `preferred_username` (e.g. Microsoft personal accounts return email only there).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct OidcUserInfo {
     pub(crate) sub: String,
     pub(crate) family_name: Option<String>,
-    pub name: String,
+    pub name: Option<String>,
     pub picture: Option<String>,
-    pub(crate) email: String,
+    pub(crate) email: Option<String>,
     pub(crate) given_name: Option<String>,
     pub(crate) hd: Option<String>,
     pub(crate) email_verified: Option<bool>,
+    /// Fallback for `email` when the provider omits the standard claim
+    /// (e.g. Microsoft personal accounts return email only in `preferred_username`).
+    pub(crate) preferred_username: Option<String>,
 }
 
 /// Build an `OAuth2Account` from an ID token payload.
@@ -86,13 +90,23 @@ pub(crate) struct OidcUserInfo {
 pub(crate) fn oauth2_account_from_idinfo(
     idinfo: &OidcIdInfo,
     provider_name: &str,
-) -> OAuth2Account {
-    OAuth2Account {
+) -> Result<OAuth2Account, OAuth2Error> {
+    let email = idinfo
+        .email
+        .clone()
+        .or_else(|| idinfo.preferred_username.clone())
+        .ok_or_else(|| {
+            OAuth2Error::Validation(format!(
+                "OIDC id_token from '{provider_name}' is missing both `email` and `preferred_username` claims"
+            ))
+        })?;
+    let name = idinfo.name.clone().unwrap_or_else(|| email.clone());
+    Ok(OAuth2Account {
         sequence_number: None,
         id: String::new(),
         user_id: String::new(),
-        name: idinfo.name.clone(),
-        email: idinfo.email.clone(),
+        name,
+        email,
         picture: idinfo.picture.clone(),
         provider: provider_name.to_string(),
         provider_user_id: format!("{}_{}", provider_name, idinfo.sub),
@@ -104,7 +118,7 @@ pub(crate) fn oauth2_account_from_idinfo(
         }),
         created_at: Utc::now(),
         updated_at: Utc::now(),
-    }
+    })
 }
 
 /// Build an `OAuth2Account` from a userinfo endpoint response.
@@ -116,13 +130,23 @@ pub(crate) fn oauth2_account_from_idinfo(
 pub(crate) fn oauth2_account_from_userinfo(
     userinfo: &OidcUserInfo,
     provider_name: &str,
-) -> OAuth2Account {
-    OAuth2Account {
+) -> Result<OAuth2Account, OAuth2Error> {
+    let email = userinfo
+        .email
+        .clone()
+        .or_else(|| userinfo.preferred_username.clone())
+        .ok_or_else(|| {
+            OAuth2Error::Validation(format!(
+                "OIDC userinfo from '{provider_name}' is missing both `email` and `preferred_username` claims"
+            ))
+        })?;
+    let name = userinfo.name.clone().unwrap_or_else(|| email.clone());
+    Ok(OAuth2Account {
         sequence_number: None,
         id: String::new(),
         user_id: String::new(),
-        name: userinfo.name.clone(),
-        email: userinfo.email.clone(),
+        name,
+        email,
         picture: userinfo.picture.clone(),
         provider: provider_name.to_string(),
         provider_user_id: format!("{}_{}", provider_name, userinfo.sub),
@@ -134,7 +158,7 @@ pub(crate) fn oauth2_account_from_userinfo(
         }),
         created_at: Utc::now(),
         updated_at: Utc::now(),
-    }
+    })
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/oauth2_passkey/src/oauth2/types/tests.rs
+++ b/oauth2_passkey/src/oauth2/types/tests.rs
@@ -3,28 +3,22 @@ use chrono::{Duration, Utc};
 use serde_json::json;
 
 /// Test conversion from OidcUserInfo to OAuth2Account via free function
-///
-/// This test verifies that a OidcUserInfo struct can be correctly converted into
-/// an OAuth2Account using `oauth2_account_from_userinfo`. It creates a OidcUserInfo
-/// object in memory with sample data and validates that all fields are properly
-/// mapped to the resulting OAuth2Account structure.
-///
 #[test]
 fn test_from_google_user_info() {
     let google_user = OidcUserInfo {
         sub: "12345".to_string(),
         family_name: Some("Doe".to_string()),
-        name: "John Doe".to_string(),
+        name: Some("John Doe".to_string()),
         picture: Some("https://example.com/pic.jpg".to_string()),
-        email: "john@example.com".to_string(),
+        email: Some("john@example.com".to_string()),
         given_name: Some("John".to_string()),
         hd: Some("example.com".to_string()),
         email_verified: Some(true),
+        preferred_username: None,
     };
 
-    let account = oauth2_account_from_userinfo(&google_user, "google");
+    let account = oauth2_account_from_userinfo(&google_user, "google").unwrap();
 
-    // Check that fields are correctly mapped
     assert_eq!(account.name, "John Doe");
     assert_eq!(account.email, "john@example.com");
     assert_eq!(
@@ -34,7 +28,6 @@ fn test_from_google_user_info() {
     assert_eq!(account.provider, "google");
     assert_eq!(account.provider_user_id, "google_12345");
 
-    // Check metadata
     let metadata = account.metadata.as_object().unwrap();
     assert_eq!(metadata["family_name"], json!("Doe"));
     assert_eq!(metadata["given_name"], json!("John"));
@@ -43,24 +36,17 @@ fn test_from_google_user_info() {
 }
 
 /// Test conversion from OidcIdInfo to OAuth2Account via free function
-///
-/// This test verifies that a OidcIdInfo struct can be correctly converted into
-/// an OAuth2Account using `oauth2_account_from_idinfo`. It creates a OidcIdInfo
-/// object in memory with ID token claims and validates that all fields are properly
-/// mapped to the resulting OAuth2Account structure.
-///
 #[test]
 fn test_from_google_id_info() {
-    // Create a mock OidcIdInfo
     let id_info = OidcIdInfo {
         iss: "https://accounts.google.com".to_string(),
         azp: Some("client_id".to_string()),
         aud: "client_id".to_string(),
         sub: "12345".to_string(),
-        email: "john@example.com".to_string(),
+        email: Some("john@example.com".to_string()),
         email_verified: Some(true),
         at_hash: Some("hash".to_string()),
-        name: "John Doe".to_string(),
+        name: Some("John Doe".to_string()),
         picture: Some("https://example.com/pic.jpg".to_string()),
         given_name: Some("John".to_string()),
         family_name: Some("Doe".to_string()),
@@ -71,11 +57,11 @@ fn test_from_google_id_info() {
         jti: Some("jti_value".to_string()),
         nonce: Some("nonce_value".to_string()),
         hd: Some("example.com".to_string()),
+        preferred_username: None,
     };
 
-    let account = oauth2_account_from_idinfo(&id_info, "google");
+    let account = oauth2_account_from_idinfo(&id_info, "google").unwrap();
 
-    // Check that fields are correctly mapped
     assert_eq!(account.name, "John Doe");
     assert_eq!(account.email, "john@example.com");
     assert_eq!(
@@ -85,7 +71,6 @@ fn test_from_google_id_info() {
     assert_eq!(account.provider, "google");
     assert_eq!(account.provider_user_id, "google_12345");
 
-    // Check metadata
     let metadata = account.metadata.as_object().unwrap();
     assert_eq!(metadata["family_name"], json!("Doe"));
     assert_eq!(metadata["given_name"], json!("John"));
@@ -93,16 +78,100 @@ fn test_from_google_id_info() {
     assert_eq!(metadata["verified_email"], json!(true));
 }
 
+/// preferred_username is used when email claim is absent (Entra personal account case)
+#[test]
+fn test_userinfo_preferred_username_fallback() {
+    let userinfo = OidcUserInfo {
+        sub: "msa_42".to_string(),
+        email: None,
+        preferred_username: Some("alice@live.com".to_string()),
+        name: Some("Alice".to_string()),
+        picture: None,
+        family_name: None,
+        given_name: None,
+        hd: None,
+        email_verified: None,
+    };
+
+    let account = oauth2_account_from_userinfo(&userinfo, "entra").unwrap();
+    assert_eq!(account.email, "alice@live.com");
+    assert_eq!(account.name, "Alice");
+}
+
+/// Error is returned when both email and preferred_username are absent
+#[test]
+fn test_userinfo_missing_email_and_preferred_username_errors() {
+    let userinfo = OidcUserInfo {
+        sub: "sub_xyz".to_string(),
+        email: None,
+        preferred_username: None,
+        name: Some("Bob".to_string()),
+        picture: None,
+        family_name: None,
+        given_name: None,
+        hd: None,
+        email_verified: None,
+    };
+
+    let result = oauth2_account_from_userinfo(&userinfo, "entra");
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("email") && msg.contains("preferred_username"));
+}
+
+/// Name falls back to email when name claim is absent
+#[test]
+fn test_userinfo_name_falls_back_to_email() {
+    let userinfo = OidcUserInfo {
+        sub: "sub_noname".to_string(),
+        email: Some("carol@example.com".to_string()),
+        preferred_username: None,
+        name: None,
+        picture: None,
+        family_name: None,
+        given_name: None,
+        hd: None,
+        email_verified: None,
+    };
+
+    let account = oauth2_account_from_userinfo(&userinfo, "entra").unwrap();
+    assert_eq!(account.name, "carol@example.com");
+    assert_eq!(account.email, "carol@example.com");
+}
+
+/// preferred_username fallback works for idinfo path too
+#[test]
+fn test_idinfo_preferred_username_fallback() {
+    let id_info = OidcIdInfo {
+        iss: "https://login.microsoftonline.com/tenant/v2.0".to_string(),
+        sub: "msa_99".to_string(),
+        azp: None,
+        aud: "client".to_string(),
+        email: None,
+        preferred_username: Some("dave@hotmail.com".to_string()),
+        email_verified: None,
+        name: Some("Dave".to_string()),
+        picture: None,
+        given_name: None,
+        family_name: None,
+        locale: None,
+        iat: 0,
+        exp: 0,
+        nbf: None,
+        jti: None,
+        nonce: None,
+        hd: None,
+        at_hash: None,
+    };
+
+    let account = oauth2_account_from_idinfo(&id_info, "entra").unwrap();
+    assert_eq!(account.email, "dave@hotmail.com");
+    assert_eq!(account.name, "Dave");
+}
+
 /// Test StoredToken to CacheData conversion roundtrip
-///
-/// This test verifies that StoredToken can be converted to CacheData and back while
-/// preserving all field values. It creates a StoredToken in memory, converts it to
-/// CacheData, then back to StoredToken, and validates that all fields including
-/// timestamps are preserved correctly through the conversion process.
-///
 #[test]
 fn test_stored_token_cache_data_conversion() {
-    // Create a StoredToken
     let now = Utc::now();
     let expires_at = now + Duration::seconds(3600);
     let stored_token = StoredToken {
@@ -112,13 +181,9 @@ fn test_stored_token_cache_data_conversion() {
         ttl: 3600,
     };
 
-    // Convert to CacheData
     let cache_data = CacheData::from(stored_token.clone());
-
-    // Convert back to StoredToken
     let recovered_token = StoredToken::try_from(cache_data).unwrap();
 
-    // Verify all fields match
     assert_eq!(recovered_token.token, stored_token.token);
     assert_eq!(
         recovered_token.expires_at.timestamp(),

--- a/oauth2_passkey_axum/src/oauth2.rs
+++ b/oauth2_passkey_axum/src/oauth2.rs
@@ -58,6 +58,11 @@ fn provider_view(name: &'static str) -> ProviderView {
             display_name: "Keycloak",
             button_class: "btn-oauth2 btn-keycloak",
         },
+        "entra" => ProviderView {
+            name,
+            display_name: "Microsoft",
+            button_class: "btn-oauth2 btn-entra",
+        },
         _ => ProviderView {
             name,
             display_name: name,

--- a/oauth2_passkey_axum/static/o2p-base.css
+++ b/oauth2_passkey_axum/static/o2p-base.css
@@ -19,6 +19,8 @@
     --o2p-auth0-hover: #c94419;
     --o2p-keycloak: #4d4d4d;
     --o2p-keycloak-hover: #333333;
+    --o2p-entra: #0078D4;
+    --o2p-entra-hover: #005A9E;
     --o2p-passkey: #818cf8;
     --o2p-passkey-hover: #6366f1;
     --o2p-danger: #dc2626;
@@ -180,6 +182,15 @@ a:hover {
 
 .btn-keycloak:hover {
     background-color: var(--o2p-keycloak-hover);
+}
+
+.btn-entra {
+    background-color: var(--o2p-entra);
+    padding: 12px 16px;
+}
+
+.btn-entra:hover {
+    background-color: var(--o2p-entra-hover);
 }
 
 .btn-passkey {


### PR DESCRIPTION
  - Relax OidcIdInfo/OidcUserInfo: email and name are now Option<String>
    per OIDC Core 1.0 (they are standard claims, not required ones)
  - Add preferred_username fallback when email is absent (Microsoft personal accounts)
  - Make Jwk.alg optional with kty-derived default (Entra omits alg in JWKS)
  - oauth2_account_from_{idinfo,userinfo} now return Result<OAuth2Account, OAuth2Error>
  - Add Entra provider (OAUTH2_ENTRA_CLIENT_ID/SECRET/ISSUER_URL, v2.0 single-tenant)
  - Add Microsoft Blue (#0078D4) login button and docs/src/guides/entra.md