### PR TITLE
fix(oauth2): accept additional origins for Entra B2C callback

### DIFF
--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -95,7 +95,7 @@ async fn authorized_core(
             "Skipping origin check for HTTP localhost callback"
         );
     } else {
-        validate_origin(headers, &auth_url).await?;
+        validate_origin(headers, &auth_url, &ctx.additional_allowed_origins).await?;
     }
 
     if auth_response.state.is_empty() {

--- a/oauth2_passkey/src/oauth2/main/utils.rs
+++ b/oauth2_passkey/src/oauth2/main/utils.rs
@@ -110,6 +110,7 @@ pub(super) async fn verify_and_consume_nonce(
 pub(crate) async fn validate_origin(
     headers: &HeaderMap,
     auth_url: &str,
+    additional_allowed_origins: &[String],
 ) -> Result<(), OAuth2Error> {
     let parsed_url = Url::parse(auth_url).expect("Invalid URL");
     let scheme = parsed_url.scheme();
@@ -129,13 +130,24 @@ pub(crate) async fn validate_origin(
         }
     };
 
+    let matches = |candidate: &str| {
+        candidate.starts_with(&expected_origin)
+            || additional_allowed_origins
+                .iter()
+                .any(|allowed| candidate.starts_with(allowed))
+    };
+
     match origin {
-        Some(origin) if origin.starts_with(&expected_origin) => Ok(()),
+        Some(origin) if matches(origin) => Ok(()),
         _ => {
             tracing::error!("Expected Origin: {:#?}", expected_origin);
+            tracing::error!(
+                "Additional allowed origins: {:#?}",
+                additional_allowed_origins
+            );
             tracing::error!("Actual Origin: {:#?}", origin);
             Err(OAuth2Error::InvalidOrigin(format!(
-                "Expected Origin: {expected_origin:#?}, Actual Origin: {origin:#?}"
+                "Expected Origin: {expected_origin:#?} (or one of {additional_allowed_origins:?}), Actual Origin: {origin:#?}"
             )))
         }
     }

--- a/oauth2_passkey/src/oauth2/main/utils/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/utils/tests.rs
@@ -166,7 +166,7 @@ async fn test_validate_origin_success() {
     headers.insert("Origin", HeaderValue::from_static("https://example.com"));
 
     // Validate against matching URL
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
 
     // Should succeed
     assert!(result.is_ok());
@@ -189,7 +189,7 @@ async fn test_validate_origin_with_referer() {
     );
 
     // Validate against matching URL
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
 
     // Should succeed
     assert!(result.is_ok());
@@ -208,7 +208,7 @@ async fn test_validate_origin_null_with_referer() {
         HeaderValue::from_static("https://example.com/login"),
     );
 
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
     assert!(
         result.is_ok(),
         "Origin: null should fall back to matching Referer"
@@ -224,7 +224,7 @@ async fn test_validate_origin_null_without_referer() {
     let mut headers = HeaderMap::new();
     headers.insert("Origin", HeaderValue::from_static("null"));
 
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
     assert!(result.is_err());
     match result {
         Err(OAuth2Error::InvalidOrigin(_)) => {}
@@ -249,7 +249,7 @@ async fn test_validate_origin_mismatch() {
     headers.insert("Origin", HeaderValue::from_static("https://attacker.com"));
 
     // Validate against different URL
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
 
     // Should fail
     assert!(result.is_err());
@@ -279,7 +279,7 @@ async fn test_validate_origin_missing() {
     let headers = HeaderMap::new();
 
     // Validate against URL
-    let result = validate_origin(&headers, "https://example.com/oauth2/callback").await;
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
 
     // Should fail
     assert!(result.is_err());
@@ -292,6 +292,36 @@ async fn test_validate_origin_missing() {
             unreachable!("Expected InvalidOrigin error, got {:?}", err);
         }
     }
+}
+
+/// Test origin validation accepts an origin listed in `additional_allowed_origins`
+///
+/// Providers like Microsoft Entra B2C route credential entry through a different
+/// host than the OIDC endpoints (e.g. `login.live.com` vs `login.microsoftonline.com`),
+/// so the Referer on the `form_post` callback is that alternate host. The provider
+/// config declares it via `additional_allowed_origins`, and `validate_origin` must
+/// accept it even though it doesn't match the authorization endpoint's origin.
+#[tokio::test]
+async fn test_validate_origin_additional_allowed() {
+    let mut headers = HeaderMap::new();
+    headers.insert("Origin", HeaderValue::from_static("null"));
+    headers.insert(
+        "Referer",
+        HeaderValue::from_static("https://login.live.com/oauth20_authorize.srf"),
+    );
+
+    let allowed = vec!["https://login.live.com".to_string()];
+    let result = validate_origin(
+        &headers,
+        "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        &allowed,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Referer on an additional_allowed_origins host should be accepted"
+    );
 }
 
 /// Test token storage and retrieval roundtrip in cache

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -136,6 +136,14 @@ pub(crate) struct ProviderConfig {
     pub(crate) query_string: String,
     /// Per-provider OIDC discovery document cache.
     pub(crate) discovery: OnceLock<OidcDiscoveryDocument>,
+    /// Extra origins that `validate_origin` should accept in addition to the
+    /// authorization endpoint's origin. Needed for providers whose login UI
+    /// is hosted on a different host than the OIDC endpoints — notably
+    /// Microsoft Entra B2C (personal MS accounts) routes credential entry
+    /// through `login.live.com` while the OIDC endpoints remain on
+    /// `login.microsoftonline.com`. Empty for providers where the login UI
+    /// and the authorization endpoint share an origin.
+    pub(crate) additional_allowed_origins: Vec<String>,
 }
 
 impl ProviderConfig {
@@ -223,6 +231,7 @@ pub(crate) static GOOGLE_PROVIDER: LazyLock<ProviderConfig> = LazyLock::new(|| {
         response_mode,
         query_string,
         discovery: OnceLock::new(),
+        additional_allowed_origins: Vec::new(),
     }
 });
 
@@ -259,6 +268,7 @@ pub(crate) static AUTH0_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock::n
         response_mode,
         query_string,
         discovery: OnceLock::new(),
+        additional_allowed_origins: Vec::new(),
     })
 });
 
@@ -293,6 +303,7 @@ pub(crate) static KEYCLOAK_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock
         response_mode,
         query_string,
         discovery: OnceLock::new(),
+        additional_allowed_origins: Vec::new(),
     })
 });
 
@@ -329,6 +340,10 @@ pub(crate) static ENTRA_PROVIDER: LazyLock<Option<ProviderConfig>> = LazyLock::n
         response_mode,
         query_string,
         discovery: OnceLock::new(),
+        // Microsoft routes personal MS account (B2C / consumers tenant) login
+        // through `login.live.com`; its Referer on the form_post callback is
+        // that host rather than `login.microsoftonline.com`.
+        additional_allowed_origins: vec!["https://login.live.com".to_string()],
     })
 });
 

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -177,6 +177,7 @@ impl ProviderConfig {
             response_mode: response_mode.to_string(),
             query_string,
             discovery,
+            additional_allowed_origins: Vec::new(),
         }
     }
 
@@ -209,6 +210,7 @@ impl ProviderConfig {
             response_mode: response_mode.to_string(),
             query_string,
             discovery,
+            additional_allowed_origins: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Microsoft Entra B2C (personal MS account / consumers tenant) routes the credential-entry UI through `login.live.com`, so the `form_post` callback arrives with `Referer: https://login.live.com/...` even though the OIDC endpoints are on `login.microsoftonline.com`. The single-host origin check rejected this as `Invalid origin`.

Add `additional_allowed_origins: Vec<String>` to `ProviderConfig` and teach `validate_origin` to accept a match against the authorization endpoint's origin OR any additional allowed origin. Entra declares `https://login.live.com`; other providers keep an empty list.