### PR TITLE
  feat(oauth2): add OAUTH2_*_PROMPT env var to configure OIDC prompt …

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,13 +6,12 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (17)
+### Open (16)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
 | `20260423-0136` | low | medium | [Consolidate idp/README.md into docs/](open/20260423-0136-idp-readme-docs-consolidation.md) |
 | `20260420-0402` | medium | small | [Admin unlink/delete fails in demo mode ("Invalid user ID")](open/20260420-0402-admin-unlink-demo-mode.md) |
-| `20260421-0315` | low | small | [Configurable `prompt` parameter per OAuth2 provider](open/20260421-0315-configurable-prompt-per-provider.md) |
 | `20260226-2020` | high | large | [Expand OAuth2 Provider Support](open/20260226-2020-expand-oauth2-providers.md) |
 | `20260226-2018` | high | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `20260226-2025` | high | large | [E2E Tests](open/20260226-2025-e2e-tests.md) |
@@ -28,10 +27,11 @@ This directory contains issue/task tracking files for the project.
 | `20260420-1457` | low | large | [Add Sign in with Apple as OAuth2 Provider](open/20260420-1457-add-apple-provider.md) |
 | `20260420-1458` | low | large | [Add GitHub as OAuth2 Provider (non-OIDC)](open/20260420-1458-add-github-provider.md) |
 
-### Completed (68)
+### Completed (69)
 
 | ID | Title |
 |----|-------|
+| `20260421-0315` | [Configurable `prompt` parameter per OAuth2 provider](completed/20260421-0315-configurable-prompt-per-provider.md) |
 | `20260422-2055` | [Introduce `ProviderName` newtype for stringly-typed provider identifiers](completed/20260422-2055-providername-newtype-typesafety.md) |
 | `20260422-1636` | [Unify non-Google providers under Custom slot with presets](completed/20260422-1636-unify-non-google-providers-via-custom-slot-preset.md) |
 | `20260422-1552` | [Detect claim mismatch between id_token and /userinfo](completed/20260422-1552-detect-claim-mismatch-idinfo-userinfo.md) |

--- a/.claude/issues/completed/20260421-0315-configurable-prompt-per-provider.md
+++ b/.claude/issues/completed/20260421-0315-configurable-prompt-per-provider.md
@@ -14,9 +14,9 @@
 
 ## Created: 2026-04-21-03-15
 
-## Closed:
+## Closed: 2026-04-23-07-00
 
-## Status: open
+## Status: completed
 
 ## Priority: low
 
@@ -124,21 +124,21 @@ Alternatives considered (rejected):
 
 ## Implementation Tasks
 
-- [ ] Add `prompt: &'static str` field to `ProviderConfig`
-- [ ] Populate named-provider statics with `prompt: "consent"` literals
-- [ ] Populate Custom-slot LazyLocks from `OAUTH2_CUSTOM{N}_PROMPT` env
-      with `"consent"` default, `Box::leak` for `&'static str`
-- [ ] Replace 5 hardcoded `&prompt=consent` occurrences with
-      `&prompt={prompt}` (skip the `&prompt=` segment entirely when
-      `prompt` is empty)
-- [ ] Extend `validate_custom_slots` to reject values outside the OIDC
-      Core 1.0 allowed set
-- [ ] Unit tests: default preserved, non-default applied, empty value
-      omits parameter, invalid value rejected at init
-- [ ] `dot.env.example`: document env var + allowed values
-- [ ] `docs/src/guides/generic-oidc.md`: add to optional-vars section,
-      cross-link from the troubleshooting entry
-- [ ] `idp/README.md`: cross-link from the Zitadel troubleshooting entry
+- [x] Add `parse_prompt` helper function (returns `Ok(None)` for empty,
+      `Ok(Some(&'static str))` for valid values, `Err` for invalid)
+- [x] Populate Google `GOOGLE_PROVIDER` LazyLock with prompt segment from
+      `OAUTH2_GOOGLE_PROMPT` (default `consent`)
+- [x] Populate Custom-slot `build_custom_provider` with prompt segment from
+      `OAUTH2_CUSTOM{N}_PROMPT` (default `consent`, panics on invalid)
+- [x] Add `validate_named_provider_prompt()` pub(crate) fn for startup check
+- [x] Wire `validate_named_provider_prompt()` into `oauth2/mod.rs` init()
+- [x] Unit tests: default applied to Google, default applied to Custom,
+      `select_account` applied, empty omits (Custom), empty omits (Google),
+      invalid value rejected at startup
+- [x] `dot.env.example`: document env var + allowed values (Google + Custom1)
+- [x] `docs/src/guides/generic-oidc.md`: add to optional-vars section,
+      cross-link from the troubleshooting entry with working example
+- [x] `idp/README.md`: cross-link from the Zitadel troubleshooting entry
 
 ## Decision Log
 
@@ -158,4 +158,37 @@ Alternatives considered (rejected):
   var and demo-side passthrough were considered and rejected for
   flexibility / API-surface reasons (see Approach / Alternatives).
 
+### 2026-04-23: Scope narrowed to `prompt` only
+
+- Context: User asked whether other OIDC params should be made configurable.
+- Decision: `prompt` only; no `hd`, `access_type`, or generic extra-params.
+- Reason: YAGNI. The issue was written before PR #319 collapsed named
+  non-Google providers into Custom slots, so the applicable env vars are
+  `OAUTH2_GOOGLE_PROMPT` and `OAUTH2_CUSTOM{N}_PROMPT` (N=1..8).
+
+### 2026-04-23: Approach refined — no ProviderConfig field needed
+
+- Context: Implementation. The issue described adding `prompt: &'static str`
+  to `ProviderConfig`, but since `prompt` is already baked into `query_string`
+  at LazyLock init, no separate field is needed. The `parse_prompt` helper
+  follows the same pattern as `parse_strict_display_claims` and
+  `validate_named_provider_strict_display_claims`. Custom slots inherit
+  startup-time validation via the existing `validate_custom_slots` LazyLock-
+  forcing pattern; only Google needs a dedicated `validate_named_provider_prompt`.
+
 ## Resolution
+
+Implemented in PR `feature/oauth2-prompt-env` on branch `feature/oauth2-prompt-env`.
+
+Key changes:
+- `parse_prompt(env_var) -> Result<Option<&'static str>, String>`: validates
+  the four OIDC Core 1.0 values plus empty string (omit parameter) and returns
+  descriptive error for unknown values.
+- `GOOGLE_PROVIDER` LazyLock: reads `OAUTH2_GOOGLE_PROMPT`, defaults to
+  `consent`, panics on invalid (caught at startup by `validate_named_provider_prompt`).
+- `build_custom_provider`: reads `OAUTH2_CUSTOM{N}_PROMPT`, same logic,
+  caught at startup by `validate_custom_slots` forcing all enabled slot LazyLocks.
+- 6 new subprocess tests covering both providers, both absent/empty/custom
+  values, and invalid-value startup rejection.
+- Docs: `dot.env.example`, `docs/src/guides/generic-oidc.md`,
+  `idp/README.md` all updated.

--- a/.claude/issues/completed/20260421-0315-configurable-prompt-per-provider.md
+++ b/.claude/issues/completed/20260421-0315-configurable-prompt-per-provider.md
@@ -192,3 +192,10 @@ Key changes:
   values, and invalid-value startup rejection.
 - Docs: `dot.env.example`, `docs/src/guides/generic-oidc.md`,
   `idp/README.md` all updated.
+
+Post-review fixes (PR #322 review follow-up):
+- Flattened `parse_prompt` inner match (removed `v @` binding and `unreachable!()`
+  arm; four literal string arms are already `&'static str`).
+- Replaced non-ASCII `→` arrows with `->` in `parse_prompt` doc comment.
+- Added `prompt_custom_login_applied` subprocess test (locks in `login` arm after
+  the simplification).

--- a/demo-live/env.cloud-run.yaml
+++ b/demo-live/env.cloud-run.yaml
@@ -28,6 +28,7 @@ OAUTH2_CUSTOM1_PRESET: auth0
 OAUTH2_CUSTOM1_ISSUER_URL: "https://dev-newrxiuvdyykkjcr.jp.auth0.com"
 OAUTH2_CUSTOM1_RESPONSE_MODE: form_post
 OAUTH2_CUSTOM1_SCOPE: "openid+email+profile"
+OAUTH2_CUSTOM1_PROMPT: login
 
 # Microsoft Entra ID via Custom slot 2 with preset. `/v2.0` suffix required.
 # Replace <tenant-id> with either your tenant UUID (B2B) or
@@ -37,6 +38,7 @@ OAUTH2_CUSTOM2_PRESET: entra
 OAUTH2_CUSTOM2_ISSUER_URL: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
 OAUTH2_CUSTOM2_RESPONSE_MODE: form_post     # default; uncomment to override
 OAUTH2_CUSTOM2_SCOPE: "openid+email+profile" # default; uncomment to override
+OAUTH2_CUSTOM2_PROMPT: login
 
 # --- Session ---
 SESSION_COOKIE_NAME: "__Host-SessionId"

--- a/demo-live/env.cloud-run.yaml
+++ b/demo-live/env.cloud-run.yaml
@@ -34,8 +34,14 @@ OAUTH2_CUSTOM1_PROMPT: login
 # Replace <tenant-id> with either your tenant UUID (B2B) or
 # 9188040d-6c67-4c5b-b112-36a304b66dad (personal MS accounts / B2C).
 # Multi-tenant `common`/`organizations` aliases are not supported.
-OAUTH2_CUSTOM2_PRESET: entra
-OAUTH2_CUSTOM2_ISSUER_URL: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
+#OAUTH2_CUSTOM2_PRESET: entra
+#OAUTH2_CUSTOM2_ISSUER_URL: "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
+#OAUTH2_CUSTOM2_RESPONSE_MODE: form_post     # default; uncomment to override
+#OAUTH2_CUSTOM2_SCOPE: "openid+email+profile" # default; uncomment to override
+#OAUTH2_CUSTOM2_PROMPT: login
+
+OAUTH2_CUSTOM2_PRESET: okta
+OAUTH2_CUSTOM2_ISSUER_URL: "https://integrator-8929177.okta.com/oauth2/default"
 OAUTH2_CUSTOM2_RESPONSE_MODE: form_post     # default; uncomment to override
 OAUTH2_CUSTOM2_SCOPE: "openid+email+profile" # default; uncomment to override
 OAUTH2_CUSTOM2_PROMPT: login

--- a/docs/src/guides/generic-oidc.md
+++ b/docs/src/guides/generic-oidc.md
@@ -102,6 +102,7 @@ OAUTH2_CUSTOM{N}_PRESET=                        # unset | auth0 | keycloak | ent
 OAUTH2_CUSTOM{N}_ICON_SLUG='openid'             # SVG basename at /o2p/icons/{slug}.svg
 OAUTH2_CUSTOM{N}_RESPONSE_MODE='form_post'      # form_post or query
 OAUTH2_CUSTOM{N}_SCOPE='openid+email+profile'
+OAUTH2_CUSTOM{N}_PROMPT='consent'               # none | login | consent | select_account | "" (omit)
 OAUTH2_CUSTOM{N}_BUTTON_COLOR='#6b7280'         # neutral gray
 OAUTH2_CUSTOM{N}_BUTTON_HOVER_COLOR='#4b5563'
 OAUTH2_CUSTOM{N}_STRICT_DISPLAY_CLAIMS=true     # see "Claim mismatch" troubleshooting
@@ -604,10 +605,8 @@ After a first successful login, subsequent OAuth2 sign-ins complete
 without the IdP showing a password or account-picker screen. The IdP
 silently reuses the existing session.
 
-This is expected OIDC behavior: oauth2-passkey sends `prompt=consent`
-on every authorization request (hardcoded in `oauth2/provider.rs` for
-every provider, named and Custom), and per OIDC Core 1.0 that only
-asks the IdP to redisplay the *consent* screen — it does not force
+This is expected OIDC behavior: per OIDC Core 1.0, `prompt=consent`
+only asks the IdP to redisplay the *consent* screen — it does not force
 re-authentication or account selection. IdPs are therefore free to
 reuse an existing authenticated session.
 
@@ -618,11 +617,27 @@ The difference between IdPs is how visibly they honor this:
   when a session exists
 - Zitadel v2's V1 login often inserts an account-picker step
 
+**Fix**: set `OAUTH2_CUSTOM{N}_PROMPT` (or `OAUTH2_GOOGLE_PROMPT` for
+Google) to change the OIDC `prompt` parameter:
+
+```bash
+# Force the account-picker on every sign-in:
+OAUTH2_CUSTOM1_PROMPT=select_account
+
+# Force re-authentication on every sign-in:
+OAUTH2_CUSTOM1_PROMPT=login
+
+# Omit the prompt parameter entirely (let the IdP decide):
+OAUTH2_CUSTOM1_PROMPT=
+```
+
+Valid values: `none`, `login`, `consent`, `select_account`, or empty
+string (omits the parameter). Default is `consent`. An invalid value
+causes startup failure with a descriptive error.
+
 If the IdP's admin console shares the browser with the demo, the
 console login creates a session the OAuth2 flow will reuse on the next
-demo sign-in.
-
-Practical workarounds for end-to-end testing:
+demo sign-in. Other testing workarounds:
 
 - Use a **private browsing window** for the demo and close it between
   runs
@@ -631,11 +646,6 @@ Practical workarounds for end-to-end testing:
   drop the IdP-side session
 - Avoid signing into the IdP admin console in the same browser profile
   you test the demo with
-
-A permanent configuration knob for the `prompt` value
-(`OAUTH2_CUSTOM{N}_PROMPT=login|select_account|consent|none`) would
-give operators control over this but is not yet implemented; track as
-a separate issue if the behavior is problematic for your deployment.
 
 ### Claim mismatch between id_token and /userinfo
 

--- a/dot.env.example
+++ b/dot.env.example
@@ -20,6 +20,9 @@ OAUTH2_ISSUER_URL='https://accounts.google.com'
 # (email / email_verified / preferred_username / hd) are always rejected
 # on mismatch; this flag does not affect them. Default: true.
 #OAUTH2_GOOGLE_STRICT_DISPLAY_CLAIMS=true
+# OIDC prompt parameter for Google. Default: consent. Empty string omits the parameter.
+# Valid values: none | login | consent | select_account | "" (to omit)
+#OAUTH2_GOOGLE_PROMPT=select_account
 
 ### Storage Configuration ###
 
@@ -100,6 +103,10 @@ GENERIC_DATA_STORE_URL='postgresql://passkey:passkey@localhost:5432/passkey'
 # between the ID token and /userinfo. Tier 1 (email / email_verified /
 # preferred_username / hd) is always strict regardless of this flag.
 #OAUTH2_CUSTOM1_STRICT_DISPLAY_CLAIMS=true
+# OIDC prompt parameter for Custom slot 1. Default: consent. Empty string omits the parameter.
+# Valid values: none | login | consent | select_account | "" (to omit). Set select_account for
+# Zitadel v4 (login-v2) to prevent silent session reuse.
+#OAUTH2_CUSTOM1_PROMPT=select_account
 #
 # ----- Examples: named IdPs via preset -----
 #

--- a/idp/README.md
+++ b/idp/README.md
@@ -587,15 +587,19 @@ After a first successful login, repeated clicks on **Continue with
 Zitadel** redirect back to the demo without showing a password or
 account-picker screen — Zitadel reuses the previous session silently.
 
-This is Zitadel's SSO behavior working as specified: oauth2-passkey
-sends `prompt=consent` (which is hardcoded across all providers in
-`oauth2/provider.rs`), and per OIDC Core that only asks the IdP to
-redisplay the *consent* screen — it does **not** force
-re-authentication or account selection. v4's login-v2 service takes
-this literally and skips straight to consent (often auto-granted),
-while v2's V1 login historically tended to show an account picker
-even with an active session, which is why the difference is
-noticeable.
+This is Zitadel's SSO behavior working as specified: per OIDC Core 1.0,
+`prompt=consent` only asks the IdP to redisplay the *consent* screen —
+it does **not** force re-authentication or account selection. v4's
+login-v2 service takes this literally and skips straight to consent
+(often auto-granted), while v2's V1 login historically tended to show
+an account picker even with an active session.
+
+**Fix**: set `OAUTH2_CUSTOM{N}_PROMPT=select_account` (force account
+picker) or `OAUTH2_CUSTOM{N}_PROMPT=login` (force re-authentication) in
+your `.env`. See the
+[IdP signs the user in without prompting](../guides/generic-oidc.md#idp-signs-the-user-in-without-prompting)
+troubleshooting entry in the generic-OIDC guide for full details and all
+valid values.
 
 If the Zitadel console shares the browser with the demo, logging into
 `/ui/console` creates a session that the OAuth2 flow will then reuse
@@ -604,6 +608,8 @@ during setup).
 
 Workarounds while testing:
 
+- Set `OAUTH2_CUSTOM{N}_PROMPT=select_account` in `.env` for an explicit
+  account-picker on every sign-in
 - Use a **private browsing window** for the demo and close it between
   runs
 - Hit Zitadel's `end_session_endpoint`
@@ -611,11 +617,6 @@ Workarounds while testing:
   session
 - Avoid logging into `/ui/console` with the same browser you use for
   the demo; create a separate test user and sign in only via the demo
-
-A permanent fix would require making `prompt` configurable per slot
-(e.g. `OAUTH2_CUSTOM{N}_PROMPT=login|select_account|consent|none`); this
-is out of scope for the generic-OIDC slot work and should be tracked
-as a separate issue if needed.
 
 ### Claim mismatch between id_token and /userinfo
 

--- a/oauth2_passkey/src/oauth2/mod.rs
+++ b/oauth2_passkey/src/oauth2/mod.rs
@@ -103,6 +103,7 @@ pub(crate) async fn init() -> Result<(), errors::OAuth2Error> {
     // values directly to avoid a request-time panic.
     provider::validate_named_provider_strict_display_claims()
         .map_err(errors::OAuth2Error::Validation)?;
+    provider::validate_named_provider_prompt().map_err(errors::OAuth2Error::Validation)?;
 
     let _ = *config::OAUTH2_CSRF_COOKIE_NAME;
     let _ = *config::OAUTH2_CSRF_COOKIE_MAX_AGE;

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -560,9 +560,11 @@ pub(crate) static GOOGLE_PROVIDER: LazyLock<ProviderConfig> = LazyLock::new(|| {
     };
     let scope = env::var("OAUTH2_SCOPE").unwrap_or_else(|_| "openid+email+profile".to_string());
     let response_type = env::var("OAUTH2_RESPONSE_TYPE").unwrap_or_else(|_| "code".to_string());
+    let prompt = parse_prompt("OAUTH2_GOOGLE_PROMPT").unwrap_or_else(|msg| panic!("{msg}"));
+    let prompt_segment = prompt.map(|p| format!("&prompt={p}")).unwrap_or_default();
     let query_string = format!(
-        "&response_type={}&scope={}&response_mode={}&access_type=online&prompt=consent",
-        response_type, scope, response_mode
+        "&response_type={}&scope={}&response_mode={}&access_type=online{}",
+        response_type, scope, response_mode, prompt_segment
     );
     let strict_display_claims = read_strict_display_claims("OAUTH2_GOOGLE_STRICT_DISPLAY_CLAIMS");
     ProviderConfig {
@@ -632,6 +634,37 @@ fn read_strict_display_claims(env_var: &str) -> bool {
 /// crash the first login request instead.
 pub(crate) fn validate_named_provider_strict_display_claims() -> Result<(), String> {
     parse_strict_display_claims("OAUTH2_GOOGLE_STRICT_DISPLAY_CLAIMS")?;
+    Ok(())
+}
+
+/// Parse an `OAUTH2_*_PROMPT` env var.
+/// - Unset → `Ok(Some("consent"))` (preserves current behavior)
+/// - `""` → `Ok(None)` (operator explicitly omits `&prompt=` from the URL)
+/// - `"none" | "login" | "consent" | "select_account"` → `Ok(Some(value))`
+/// - Any other value → `Err(message)` for startup-time rejection
+fn parse_prompt(env_var: &str) -> Result<Option<&'static str>, String> {
+    match env::var(env_var).ok().as_deref() {
+        None => Ok(Some("consent")),
+        Some("") => Ok(None),
+        Some(v @ ("none" | "login" | "consent" | "select_account")) => Ok(Some(match v {
+            "consent" => "consent",
+            "none" => "none",
+            "login" => "login",
+            "select_account" => "select_account",
+            _ => unreachable!(),
+        })),
+        Some(other) => Err(format!(
+            "Invalid {env_var} '{other}'. \
+             Must be one of: none, login, consent, select_account \
+             (or empty to omit the parameter)."
+        )),
+    }
+}
+
+/// Validate `OAUTH2_GOOGLE_PROMPT` at startup without forcing `GOOGLE_PROVIDER`'s
+/// `LazyLock` to initialize. Custom slots are caught via `validate_custom_slots`.
+pub(crate) fn validate_named_provider_prompt() -> Result<(), String> {
+    parse_prompt("OAUTH2_GOOGLE_PROMPT")?;
     Ok(())
 }
 
@@ -724,9 +757,11 @@ fn build_custom_provider(slot: CustomSlot) -> Option<ProviderConfig> {
         O2P_ROUTE_PREFIX.as_str(),
         provider_name
     );
+    let prompt = parse_prompt(&format!("{prefix}_PROMPT")).unwrap_or_else(|msg| panic!("{msg}"));
+    let prompt_segment = prompt.map(|p| format!("&prompt={p}")).unwrap_or_default();
     let query_string = format!(
-        "&response_type=code&scope={}&response_mode={}&prompt=consent",
-        scope, response_mode
+        "&response_type=code&scope={}&response_mode={}{}",
+        scope, response_mode, prompt_segment
     );
 
     Some(ProviderConfig {

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -638,21 +638,18 @@ pub(crate) fn validate_named_provider_strict_display_claims() -> Result<(), Stri
 }
 
 /// Parse an `OAUTH2_*_PROMPT` env var.
-/// - Unset → `Ok(Some("consent"))` (preserves current behavior)
-/// - `""` → `Ok(None)` (operator explicitly omits `&prompt=` from the URL)
-/// - `"none" | "login" | "consent" | "select_account"` → `Ok(Some(value))`
-/// - Any other value → `Err(message)` for startup-time rejection
+/// - Unset -> `Ok(Some("consent"))` (preserves current behavior)
+/// - `""` -> `Ok(None)` (operator explicitly omits `&prompt=` from the URL)
+/// - `"none" | "login" | "consent" | "select_account"` -> `Ok(Some(value))`
+/// - Any other value -> `Err(message)` for startup-time rejection
 fn parse_prompt(env_var: &str) -> Result<Option<&'static str>, String> {
     match env::var(env_var).ok().as_deref() {
         None => Ok(Some("consent")),
         Some("") => Ok(None),
-        Some(v @ ("none" | "login" | "consent" | "select_account")) => Ok(Some(match v {
-            "consent" => "consent",
-            "none" => "none",
-            "login" => "login",
-            "select_account" => "select_account",
-            _ => unreachable!(),
-        })),
+        Some("none") => Ok(Some("none")),
+        Some("login") => Ok(Some("login")),
+        Some("consent") => Ok(Some("consent")),
+        Some("select_account") => Ok(Some("select_account")),
         Some(other) => Err(format!(
             "Invalid {env_var} '{other}'. \
              Must be one of: none, login, consent, select_account \

--- a/oauth2_passkey/src/oauth2/provider.rs
+++ b/oauth2_passkey/src/oauth2/provider.rs
@@ -966,6 +966,7 @@ pub(crate) fn validate_custom_slot_preset_shape() -> Result<(), String> {
                 ));
             }
         }
+        parse_prompt(&format!("{prefix}_PROMPT"))?;
     }
     Ok(())
 }

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -1010,6 +1010,164 @@ fn custom_slot_preset_invalid_value_rejected_at_startup() {
     );
 }
 
+// --- OAUTH2_*_PROMPT env-var tests ---
+
+#[test]
+fn prompt_default_applied_to_google_query_string() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        assert!(
+            GOOGLE_PROVIDER.query_string.contains("&prompt=consent"),
+            "default must produce &prompt=consent; got: {}",
+            GOOGLE_PROVIDER.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_default_applied_to_google_query_string",
+        &[],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn prompt_default_applied_to_custom_query_string() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let cfg =
+            provider_for(ProviderKind::Custom(CustomSlot::Slot1)).expect("slot1 should be enabled");
+        assert!(
+            cfg.query_string.contains("&prompt=consent"),
+            "default must produce &prompt=consent; got: {}",
+            cfg.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_default_applied_to_custom_query_string",
+        &[
+            ("OAUTH2_CUSTOM1_CLIENT_ID", "id"),
+            ("OAUTH2_CUSTOM1_CLIENT_SECRET", "sec"),
+            ("OAUTH2_CUSTOM1_ISSUER_URL", "https://idp.example.com"),
+            ("OAUTH2_CUSTOM1_DISPLAY_NAME", "X"),
+            ("OAUTH2_CUSTOM1_NAME", "x"),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn prompt_custom_select_account_applied() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let cfg =
+            provider_for(ProviderKind::Custom(CustomSlot::Slot1)).expect("slot1 should be enabled");
+        assert!(
+            cfg.query_string.contains("&prompt=select_account"),
+            "must contain &prompt=select_account; got: {}",
+            cfg.query_string
+        );
+        assert!(
+            !cfg.query_string.contains("&prompt=consent"),
+            "must not contain &prompt=consent; got: {}",
+            cfg.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_custom_select_account_applied",
+        &[
+            ("OAUTH2_CUSTOM1_CLIENT_ID", "id"),
+            ("OAUTH2_CUSTOM1_CLIENT_SECRET", "sec"),
+            ("OAUTH2_CUSTOM1_ISSUER_URL", "https://idp.example.com"),
+            ("OAUTH2_CUSTOM1_DISPLAY_NAME", "X"),
+            ("OAUTH2_CUSTOM1_NAME", "x"),
+            ("OAUTH2_CUSTOM1_PROMPT", "select_account"),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn prompt_empty_omits_parameter_custom() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let cfg =
+            provider_for(ProviderKind::Custom(CustomSlot::Slot1)).expect("slot1 should be enabled");
+        assert!(
+            !cfg.query_string.contains("prompt="),
+            "empty PROMPT must omit the parameter entirely; got: {}",
+            cfg.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_empty_omits_parameter_custom",
+        &[
+            ("OAUTH2_CUSTOM1_CLIENT_ID", "id"),
+            ("OAUTH2_CUSTOM1_CLIENT_SECRET", "sec"),
+            ("OAUTH2_CUSTOM1_ISSUER_URL", "https://idp.example.com"),
+            ("OAUTH2_CUSTOM1_DISPLAY_NAME", "X"),
+            ("OAUTH2_CUSTOM1_NAME", "x"),
+            ("OAUTH2_CUSTOM1_PROMPT", ""),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn prompt_empty_omits_parameter_google() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        assert!(
+            !GOOGLE_PROVIDER.query_string.contains("prompt="),
+            "empty OAUTH2_GOOGLE_PROMPT must omit the parameter; got: {}",
+            GOOGLE_PROVIDER.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_empty_omits_parameter_google",
+        &[("OAUTH2_GOOGLE_PROMPT", "")],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn prompt_invalid_value_rejected_at_startup() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let err = validate_named_provider_prompt()
+            .expect_err("invalid prompt value must be rejected at startup");
+        assert!(err.contains("OAUTH2_GOOGLE_PROMPT"));
+        assert!(err.contains("foobar"));
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_invalid_value_rejected_at_startup",
+        &[("OAUTH2_GOOGLE_PROMPT", "foobar")],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn custom_slot_no_preset_requires_display_name_and_name() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -1098,6 +1098,41 @@ fn prompt_custom_select_account_applied() {
 }
 
 #[test]
+fn prompt_custom_login_applied() {
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let cfg =
+            provider_for(ProviderKind::Custom(CustomSlot::Slot1)).expect("slot1 should be enabled");
+        assert!(
+            cfg.query_string.contains("&prompt=login"),
+            "must contain &prompt=login; got: {}",
+            cfg.query_string
+        );
+        assert!(
+            !cfg.query_string.contains("&prompt=consent"),
+            "must not contain &prompt=consent; got: {}",
+            cfg.query_string
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::prompt_custom_login_applied",
+        &[
+            ("OAUTH2_CUSTOM1_CLIENT_ID", "id"),
+            ("OAUTH2_CUSTOM1_CLIENT_SECRET", "sec"),
+            ("OAUTH2_CUSTOM1_ISSUER_URL", "https://idp.example.com"),
+            ("OAUTH2_CUSTOM1_DISPLAY_NAME", "X"),
+            ("OAUTH2_CUSTOM1_NAME", "x"),
+            ("OAUTH2_CUSTOM1_PROMPT", "login"),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn prompt_empty_omits_parameter_custom() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
         let cfg =

--- a/oauth2_passkey/src/oauth2/provider/tests.rs
+++ b/oauth2_passkey/src/oauth2/provider/tests.rs
@@ -1169,6 +1169,42 @@ fn prompt_invalid_value_rejected_at_startup() {
 }
 
 #[test]
+fn custom_slot_invalid_prompt_rejected_as_validation_error() {
+    // Regression guard for the P2 review finding: invalid OAUTH2_CUSTOM{N}_PROMPT
+    // must surface as a clean Err from validate_custom_slot_preset_shape(), not as
+    // a panic inside the LazyLock init path that validate_custom_slots() forces.
+    if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
+        let err = validate_custom_slot_preset_shape()
+            .expect_err("invalid PROMPT must be rejected pre-LazyLock");
+        assert!(
+            err.contains("OAUTH2_CUSTOM1_PROMPT"),
+            "error must name the offending var; got: {err}"
+        );
+        assert!(
+            err.contains("badprompt"),
+            "error must include the bad value; got: {err}"
+        );
+        return;
+    }
+    let output = run_child_with_env_set(
+        "oauth2::provider::tests::custom_slot_invalid_prompt_rejected_as_validation_error",
+        &[
+            ("OAUTH2_CUSTOM1_CLIENT_ID", "id"),
+            ("OAUTH2_CUSTOM1_CLIENT_SECRET", "sec"),
+            ("OAUTH2_CUSTOM1_ISSUER_URL", "https://idp.example.com"),
+            ("OAUTH2_CUSTOM1_DISPLAY_NAME", "X"),
+            ("OAUTH2_CUSTOM1_NAME", "x"),
+            ("OAUTH2_CUSTOM1_PROMPT", "badprompt"),
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn custom_slot_no_preset_requires_display_name_and_name() {
     if std::env::var("__TEST_ENV_VAR_CHILD").is_ok() {
         let err = validate_custom_slot_preset_shape()


### PR DESCRIPTION
…parameter

  `prompt=consent` was hardcoded for every provider. Per OIDC Core 1.0
  that only requests the consent screen, not re-auth or account selection,
  so IdPs (notably Zitadel v4 login-v2) are free to reuse existing
  sessions silently.

  New env vars:
    OAUTH2_GOOGLE_PROMPT        (Google named provider)
    OAUTH2_CUSTOM{N}_PROMPT     (every Custom slot, N=1..8)

  Accepted values: none | login | consent | select_account | "" (omit).
  Default is `consent` -- no behavior change for existing deployments.
  An invalid value causes startup failure with a descriptive error.

  Implementation follows the parse_strict_display_claims /
  validate_named_provider_strict_display_claims pattern:
  - parse_prompt() helper returns Ok(None) for empty, Ok(Some(...)) for valid values, Err(...) for unknown values
  - validate_named_provider_prompt() catches bad OAUTH2_GOOGLE_PROMPT at startup without forcing the GOOGLE_PROVIDER LazyLock to initialize
  - Custom slots are caught via the existing validate_custom_slots LazyLock-forcing path

  Adds 6 subprocess tests (default on Google, default on Custom,
  select_account applied, empty omits for both providers, invalid
  rejected at startup). Docs: dot.env.example, generic-oidc.md,
  idp/README.md. Closes issue 20260421-0315.

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>