### PR TITLE
  chore: prepare for v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,44 @@ All notable changes to oauth2-passkey will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1-dev]
+## [0.6.0] - 2026-05-11
+
+### Added
+
+- **Generic OIDC provider slots** — eight `OAUTH2_CUSTOM{N}_*` slots
+  (`CUSTOM1`..`CUSTOM8`) for arbitrary OIDC IdPs alongside Google.
+  Endpoints (authorization, token, JWKS, userinfo) are auto-discovered
+  from `/.well-known/openid-configuration`. Per-slot env vars:
+  `CLIENT_ID`, `CLIENT_SECRET`, `ISSUER_URL`, `NAME`, `DISPLAY_NAME`,
+  `SCOPE`, `RESPONSE_MODE`, `PROMPT`, `ICON_SLUG`, `BUTTON_COLOR`,
+  `BUTTON_HOVER_COLOR`, `STRICT_DISPLAY_CLAIMS`, `PRESET` (#316, #319)
+- **Provider presets** — `OAUTH2_CUSTOM{N}_PRESET=<name>` pre-fills
+  display name, icon, button colors, and any IdP-specific quirks
+  (e.g. additional allowed origins for Entra personal accounts).
+  Built-in presets: `auth0`, `keycloak`, `entra`, `zitadel`, `okta`,
+  `authentik`, `line`, `apple`. Any preset field can be individually
+  overridden by setting the corresponding `OAUTH2_CUSTOM{N}_*` env var
+- HS256 / HS384 ID token signature support (HMAC keyed on
+  `client_secret`) for providers that do not sign with RSA/ECDSA
+  (e.g. LINE Login web flow)
+- `OAUTH2_*_PROMPT` env var to configure the OIDC `prompt` parameter
+  per provider (default remains `consent`). Invalid values are
+  rejected at startup
+- `OAUTH2_*_STRICT_DISPLAY_CLAIMS` per-provider toggle: hard-reject
+  (vs. warn on) `name` / `picture` divergence between the ID token
+  and `/userinfo`
+- Multi-provider login UI: provider selection popup appears when more
+  than one OIDC provider is configured, with per-provider branded
+  login button (icon + brand color)
+- IDP icon and provider name shown on OAuth2 account cards on both
+  the user account page and the admin user detail page (#313, #314)
+- Public API: `ProviderName` newtype, `ProviderInfo` struct, and
+  introspection helpers `enabled_providers()`, `is_provider_enabled()`,
+  `provider_info()` for runtime discovery of configured providers
+- Local IdP bring-up scripts and E2E setup notes under `idp/`
+  (Keycloak, Authentik, Zitadel, Hydra) and dedicated provider
+  setup guides under `docs/src/guides/` (Auth0, Keycloak, Entra,
+  LINE, Apple, generic-oidc)
 
 ### Changed
 
@@ -18,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OAuth2Account.email` / `.name` remain non-optional; the conversion layer
     uses `preferred_username` or errors with `OAuth2Error::Validation` if no
     email claim is available.
+- **Breaking**: `OidcTokenResponse.expires_in` is now `Option<u64>`
+  (previously `u64`) and `OidcTokenResponse.scope` is now `Option<String>`
+  (previously `String`), per RFC 6749 §5.1 which classifies both fields
+  as RECOMMENDED rather than REQUIRED. Required for providers like
+  older Keycloak builds, Ory Hydra, and Zitadel that may omit them
 - **Breaking**: `PASSKEY_AUTHENTICATOR_ATTACHMENT=none` is no longer accepted —
   the previous mapping emitted the non-spec JSON value `"None"`, which only
   worked because of browser leniency. To allow either platform or
@@ -27,6 +69,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registration JSON (= "either is acceptable"). Operators who relied on the
   previous default of `=platform` to force platform-bound authenticators must
   now set `PASSKEY_AUTHENTICATOR_ATTACHMENT=platform` explicitly.
+- OAuth2 callback now **merges** claims from both the ID token and
+  `/userinfo` (preferring `/userinfo` as the canonical profile source,
+  falling back to the ID token) instead of using one or the other.
+  Eliminates failure modes where a provider populates a field in only
+  one of the two responses
+
+### Security
+
+- Identity-critical claim mismatches between the ID token and
+  `/userinfo` (`sub`, `email`, `email_verified`) are now strictly
+  rejected with `OAuth2Error::Validation`. Display-claim mismatches
+  (`name`, `picture`) follow the per-provider `STRICT_DISPLAY_CLAIMS`
+  setting (warn by default, reject when strict)
+- ID tokens with multiple audiences are validated against the `azp`
+  (authorized party) claim per OIDC Core 1.0 §3.1.3.7 — previously
+  multi-audience tokens passed validation with only the `aud` check
+- Optional-provider env var contracts (`{TRIGGER}` set ⇒ `{required}`
+  set) are validated at startup; missing companions cause an
+  immediate panic instead of failing on the first OAuth2 login
+- Named-provider `STRICT_DISPLAY_CLAIMS` and `PROMPT` env values are
+  validated at startup, eliminating delayed panics on first request
+- Update rustls-webpki 0.103.10 -> 0.103.13 (#303), resolving:
+  - RUSTSEC-2026-0098: name constraints for URI names incorrectly accepted
+  - RUSTSEC-2026-0099: name constraints accepted for wildcard certs
+  - RUSTSEC-2026-0104: reachable panic in CRL parsing
+
+### Fixed
+
+- Admin actions (Unlink OAuth2 account / Delete passkey credential)
+  failed with "Invalid user ID" when an admin viewed another user's
+  detail page in `O2P_DEMO_MODE`. Destructive admin buttons are now
+  hidden when resource identifiers are masked (#328)
 
 ## [0.5.0] - 2026-03-23
 
@@ -327,6 +401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full WebAuthn specification compliance
 - Comprehensive security documentation and best practices guide
 
+[0.6.0]: https://github.com/ktaka-ccmp/oauth2-passkey/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ktaka-ccmp/oauth2-passkey/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ktaka-ccmp/oauth2-passkey/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ktaka-ccmp/oauth2-passkey/compare/v0.2.0...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "askama"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -53,12 +53,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -70,18 +71,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -102,7 +103,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -348,19 +349,13 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -544,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-queue"
@@ -638,13 +633,13 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "demo-both"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -660,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "demo-cross-origin"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -676,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "demo-custom-login"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -689,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "demo-live"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -703,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "demo-oauth2"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -717,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "demo-passkey"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -732,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "demo-profile"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -750,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "demo-todo"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -814,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1154,6 +1149,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1207,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1280,7 +1281,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1345,9 +1346,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1539,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1554,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1566,16 +1567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,27 +1574,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1627,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1677,9 +1673,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1696,7 +1692,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -1907,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "oauth2-passkey"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "async-trait",
  "axum",
@@ -1931,7 +1927,7 @@ dependencies = [
  "sha2 0.11.0",
  "sqlx",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -1943,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "oauth2-passkey-axum"
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 dependencies = [
  "askama",
  "axum",
@@ -2312,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
+checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -2346,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2384,9 +2380,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2507,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -2533,18 +2529,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -2812,7 +2808,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2851,6 +2847,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,15 +2870,15 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2953,7 +2965,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3037,7 +3049,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -3076,7 +3088,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uuid",
  "whoami",
@@ -3102,7 +3114,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
  "uuid",
@@ -3198,31 +3210,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3303,9 +3295,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3382,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3395,7 +3387,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -3405,7 +3396,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3658,9 +3649,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3671,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3681,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3691,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3704,9 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3747,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3874,15 +3865,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3906,21 +3888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3956,12 +3923,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3974,12 +3935,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3989,12 +3944,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4016,12 +3965,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4031,12 +3974,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4052,12 +3989,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4067,12 +3998,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4209,7 +4134,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1-dev"
+version = "0.6.0-dev"
 edition = "2024"
 
 [workspace.dependencies]
 # Common packages
-askama = { version = "0.15.6" }
+askama = { version = "0.16.0" }
 async-trait = "0.1.89"
 axum = { version = "0.8", features = ["http2", "macros", "multipart"] }
 axum-core = "0.5.6"
@@ -30,7 +30,7 @@ chrono-tz = "0.10.4"
 dotenvy = "0.15.7"
 headers = "0.4.1"
 http = "1.4.0"
-rustls = { version = "0.23.38", default-features = false, features = ["ring", "std", "tls12"] }
+rustls = { version = "0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sqlx = { version = "0.8", features = [
@@ -70,8 +70,8 @@ hmac = "0.13.0"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 oid-registry = "0.8.1"
 proptest = "1.11.0"
-redis = { version = "1.2.0", features = ["tokio-comp"] }
-reqwest = { version = "0.13.2", default-features = false, features = [
+redis = { version = "1.2.1", features = ["tokio-comp"] }
+reqwest = { version = "0.13.3", default-features = false, features = [
     "rustls-no-provider", "charset", "http2", "json", "cookies", "form", "system-proxy",
 ] }
 ring = { version = "0.17.14", features = ["std"] }

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ No setup required. Google account needed for OAuth2. Data is ephemeral (resets o
 
 ```toml
 [dependencies]
-oauth2-passkey-axum = "0.5"
+oauth2-passkey-axum = "0.6"
 ```
 
 **2. Set your environment variables:**

--- a/docs/src/api/axum.md
+++ b/docs/src/api/axum.md
@@ -413,13 +413,13 @@ API endpoints (`/user/info`, `/user/csrf_token`, `/user/logout`, `/user/update`,
 
 ```toml
 # Disable all built-in UI
-oauth2-passkey-axum = { version = "0.5", default-features = false }
+oauth2-passkey-axum = { version = "0.6", default-features = false }
 
 # Custom login page, keep account management and admin UI
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["user-ui", "admin-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["user-ui", "admin-ui"] }
 
 # Keep admin UI only
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["login-ui", "admin-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["login-ui", "admin-ui"] }
 ```
 
 ### Additional Router: `passkey_well_known_router()`

--- a/docs/src/appendix/security-advisories.md
+++ b/docs/src/appendix/security-advisories.md
@@ -22,16 +22,24 @@ The Marvin Attack is a potential key recovery attack through timing side-channel
 - Removed `pkcs1` crate dependency used for PEM conversion
 
 **Remaining Exposure:**
-- Transitive dependency through `sqlx-mysql` → `rsa` crate (via SQLx macros)
-- **Impact:** None - we only use SQLite and PostgreSQL features, never MySQL
+- Transitive dependency through `sqlx-mysql` → `rsa` crate
+- Pulled in two ways:
+  1. SQLx's macro system (`sqlx-macros-core`) includes all database drivers at compile time
+  2. The `mysql` feature added in v0.5.0 enables the runtime driver
+- **Impact:** None - the Marvin Attack targets RSA *decryption* timing
+  to recover a private key, but `sqlx-mysql` only performs RSA *public-key
+  encryption* of the password during the MySQL `caching_sha2_password`
+  authentication handshake. The client never holds an RSA private key, so
+  no decryption oracle exists in this code path
 - **Risk:** Minimal - vulnerability not in our execution path
-- **CI Status:** Advisory ignored (RUSTSEC-2023-0071) due to unused dependency path
+- **CI Status:** Advisory ignored (RUSTSEC-2023-0071)
 
 **Technical Details:**
-- SQLx's macro system (`sqlx-macros-core`) includes all database drivers at compile time
-- This is a known SQLx architectural limitation
-- MySQL driver dependencies are never loaded or executed in our applications
-- All actual database operations use only SQLite or PostgreSQL drivers
+- Even with MySQL backend selected (`GENERIC_DATA_STORE_TYPE=mysql`), the
+  client only encrypts outbound credentials with the server's public key
+- Marvin Attack mitigation is the responsibility of the MySQL server
+  (which holds the private key), not the Rust client
+- SQLite and PostgreSQL backends do not pull `sqlx-mysql` at runtime at all
 
 #### Migration Details
 
@@ -71,5 +79,5 @@ Ok(DecodingKey::from_rsa_components(n, e)?)
 
 ---
 
-*Last Updated: June 22, 2025*
+*Last Updated: 2026-05-11 (revised for v0.5.0 MySQL support)*
 *Review Frequency: Quarterly or upon new RSA crate releases*

--- a/docs/src/integration/customizing-templates.md
+++ b/docs/src/integration/customizing-templates.md
@@ -216,7 +216,7 @@ To disable the built-in admin UI and create your own:
 ```toml
 # Cargo.toml
 [dependencies]
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["user-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["user-ui"] }
 ```
 
 ### Admin Privilege Check
@@ -465,16 +465,16 @@ Configure these in your `Cargo.toml` based on which pages you're replacing:
 
 ```toml
 # Replace ALL pages with custom templates (recommended for full customization)
-oauth2-passkey-axum = { version = "0.5", default-features = false }
+oauth2-passkey-axum = { version = "0.6", default-features = false }
 
 # Custom login page only, keep built-in account management and admin UI
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["user-ui", "admin-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["user-ui", "admin-ui"] }
 
 # Replace only admin pages, keep built-in login and account management
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["login-ui", "user-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["login-ui", "user-ui"] }
 
 # Replace only user pages, keep built-in login and admin
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["login-ui", "admin-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["login-ui", "admin-ui"] }
 ```
 
 **Note:** API endpoints (logout, delete account, admin operations, etc.) are always available regardless of feature flags. Only the HTML pages and their static assets are affected.

--- a/docs/src/integration/server-setup.md
+++ b/docs/src/integration/server-setup.md
@@ -212,7 +212,7 @@ For minimal container deployments (scratch or alpine Docker images) where system
 
 ```toml
 [dependencies]
-oauth2-passkey-axum = { version = "0.5", features = ["bundled-tls"] }
+oauth2-passkey-axum = { version = "0.6", features = ["bundled-tls"] }
 ```
 
 This bundles certificates from the `webpki-roots` crate and configures ALPN protocol negotiation for proper TLS handshakes.
@@ -251,7 +251,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenvy = "0.15"
 askama = "0.12"
-oauth2-passkey-axum = "0.5"
+oauth2-passkey-axum = "0.6"
 ```
 
 ## Startup Sequence

--- a/oauth2_passkey_axum/README.md
+++ b/oauth2_passkey_axum/README.md
@@ -54,7 +54,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-oauth2-passkey-axum = "0.5"
+oauth2-passkey-axum = "0.6"
 ```
 
 ### Prepare .env
@@ -149,7 +149,7 @@ Disable features you don't need:
 ```toml
 [dependencies]
 # Custom login page, keep built-in account management and admin UI
-oauth2-passkey-axum = { version = "0.5", default-features = false, features = ["user-ui", "admin-ui"] }
+oauth2-passkey-axum = { version = "0.6", default-features = false, features = ["user-ui", "admin-ui"] }
 ```
 
 ## Available Routes


### PR DESCRIPTION
  - Rename CHANGELOG [0.5.1-dev] to [0.6.0] - 2026-05-11 with full release notes (generic OIDC slots, presets, HS256/HS384, multi- provider UI, ProviderName API, security tightenings)
  - Bump workspace version 0.5.1-dev -> 0.6.0-dev
  - Update doc references oauth2-passkey-axum 0.5 -> 0.6 (5 files)
  - Refresh security-advisories.md for v0.5.0 MySQL support
  - Sync Cargo.lock with cargo_prep.sh dependency updates (askama 0.16, rustls 0.23.40, redis 1.2.1, reqwest 0.13.3, rustls-webpki 0.103.13 resolves RUSTSEC-2026-0098/-0099/-0104)

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>