### PR TITLE
  docs: address PR #295 review feedback

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (9)
+### Open (10)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -17,6 +17,7 @@ This directory contains issue/task tracking files for the project.
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
+| `20260511-0543` | medium | low | [validate_origin starts_with subdomain confusion via Referer](open/20260511-0543-validate-origin-subdomain-confusion.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 

--- a/.claude/issues/open/20260511-0543-validate-origin-subdomain-confusion.md
+++ b/.claude/issues/open/20260511-0543-validate-origin-subdomain-confusion.md
@@ -1,0 +1,127 @@
+# Issue: validate_origin `starts_with` allows subdomain confusion via Referer
+
+## Table of Contents
+
+- [Description](#description)
+- [Reproduction](#reproduction)
+- [Proposed Fix](#proposed-fix)
+- [Related Files](#related-files)
+- [Timeline](#timeline)
+
+## ID: 20260511-0543
+
+## Created: 2026-05-11-05-43
+
+## Status: open
+
+## Priority: medium
+
+## Difficulty: low
+
+## Description
+
+`validate_origin` in `oauth2_passkey/src/oauth2/main/utils.rs:129-134`
+uses a raw `starts_with` to compare the incoming Origin/Referer header
+against `expected_origin` and against each entry in
+`additional_allowed_origins`. The expected value has no trailing
+delimiter (it is built as `"{scheme}://{host}[:{port}]"`), so any
+candidate that begins with the expected string but has additional
+arbitrary characters in the host segment will satisfy the check.
+
+For `expected_origin = "https://accounts.google.com"`, a `Referer` of
+`https://accounts.google.com.attacker.com/path` passes the check
+because `.` is a valid host-segment character — the prefix match does
+not anchor on a host-segment boundary.
+
+The same pattern now applies to `additional_allowed_origins`, which
+the v0.6.0 preset system uses to register IdP-specific extras (e.g.
+`https://login.live.com` for the Entra personal-accounts flow). The
+attack surface widens with every additional allowed origin.
+
+Surfaced by code review of PR #295 (v0.6.0 release).
+
+### Real-world reachability
+
+Constrained. An attacker needs the browser to send a Referer whose
+host starts with the allowed origin and continues with attacker-
+controlled characters. That requires one of:
+
+- DNS takeover of a name that subsumes the legitimate origin
+- An open-redirect chain at the IdP host that sets the Referer
+- An attacker-controlled subdomain when the allowed origin is itself
+  a subdomain prefix (less likely in the OAuth2 callback flow)
+
+The `Origin` header path (preferred over `Referer`) is unaffected in
+practice because browsers send exact origins with no path, but the
+fallback `Referer` path is reachable.
+
+This is a defense-in-depth hardening, not a known active vulnerability.
+
+## Reproduction
+
+Conceptual — set `expected_origin = "https://accounts.google.com"` and
+call `validate_origin` with a `Referer` header of
+`https://accounts.google.com.attacker.com/path`. Current code returns
+`Ok(())`.
+
+## Proposed Fix
+
+Anchor the prefix match on a host-segment boundary. Two equivalent
+approaches:
+
+### Option A — parse and compare structurally
+
+Parse the candidate as a URL and compare `scheme + host + port`
+exactly against `expected_origin` (and each `additional_allowed_origin`).
+Requires pulling `url` crate (already a transitive dep) or doing a
+manual split on the first `/` after `scheme://`.
+
+### Option B — byte-after-prefix check
+
+After `starts_with(allowed)` returns true, verify that the candidate
+byte at position `allowed.len()` is one of `/`, `?`, `#`, or that the
+prefix is the entire candidate. This is a minimal patch and avoids
+adding parser dependencies.
+
+```rust
+let matches = |candidate: &str| {
+    let allowed_prefixes = std::iter::once(expected_origin.as_str())
+        .chain(additional_allowed_origins.iter().map(|s| s.as_str()));
+    allowed_prefixes.any(|allowed| {
+        if !candidate.starts_with(allowed) {
+            return false;
+        }
+        match candidate.as_bytes().get(allowed.len()) {
+            None | Some(b'/') | Some(b'?') | Some(b'#') => true,
+            _ => false,
+        }
+    })
+};
+```
+
+Option B is recommended — smaller surface change, no new dependency,
+straightforward to test.
+
+## Related Files
+
+### To modify
+
+- `oauth2_passkey/src/oauth2/main/utils.rs` — `validate_origin` body
+- `oauth2_passkey/src/oauth2/main/utils/tests.rs` — add negative tests:
+  - `https://accounts.google.com.attacker.com/path` rejected
+  - `https://login.live.com.attacker.example` rejected
+  - `https://accounts.google.com/path?query=...` still accepted
+  - `https://accounts.google.com:443` correctness if port encoded
+
+## Timeline
+
+<!-- APPEND-ONLY: Add new entries at the bottom. -->
+
+### 2026-05-11: Filed during v0.6.0 release review
+
+- Surfaced by code review of PR #295 (review-295.txt § Findings worth
+  fixing item 1). Reviewer's recommendation: pre-tag fix or follow-up.
+- Decision: defer to follow-up (file issue, do not block v0.6.0). The
+  v0.6.0 release prep is doc-accuracy fixes only; this is a code change
+  that warrants its own PR with negative tests.
+- Reference: review-295.txt § "Findings worth fixing" item 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,18 +70,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previous default of `=platform` to force platform-bound authenticators must
   now set `PASSKEY_AUTHENTICATOR_ATTACHMENT=platform` explicitly.
 - OAuth2 callback now **merges** claims from both the ID token and
-  `/userinfo` (preferring `/userinfo` as the canonical profile source,
-  falling back to the ID token) instead of using one or the other.
-  Eliminates failure modes where a provider populates a field in only
-  one of the two responses
+  `/userinfo` (preferring the ID token as the cryptographically
+  signed source, falling back to `/userinfo` to fill missing fields)
+  instead of using one or the other. Eliminates failure modes where
+  a provider populates a field in only one of the two responses
 
 ### Security
 
 - Identity-critical claim mismatches between the ID token and
-  `/userinfo` (`sub`, `email`, `email_verified`) are now strictly
-  rejected with `OAuth2Error::Validation`. Display-claim mismatches
-  (`name`, `picture`) follow the per-provider `STRICT_DISPLAY_CLAIMS`
-  setting (warn by default, reject when strict)
+  `/userinfo` (`email`, `email_verified`, `preferred_username`, `hd`)
+  are now strictly rejected with `OAuth2Error::Validation`. The `sub`
+  equality invariant is enforced upstream in `get_idinfo_userinfo` as
+  `OAuth2Error::IdMismatch`. Display-claim mismatches (`name`,
+  `picture`, `family_name`, `given_name`) follow the per-provider
+  `STRICT_DISPLAY_CLAIMS` setting (warn by default, reject when strict)
 - ID tokens with multiple audiences are validated against the `azp`
   (authorized party) claim per OIDC Core 1.0 §3.1.3.7 — previously
   multi-audience tokens passed validation with only the `aud` check

--- a/demo-live/DEPLOY.md
+++ b/demo-live/DEPLOY.md
@@ -136,6 +136,29 @@ The `/v2.0` suffix is required — the v1 endpoint uses a different issuer forma
 (`sts.windows.net`) that will fail issuer validation. The `common` and
 `organizations` aliases are also not supported.
 
+### Step 2c: Create LINE Login credentials (optional)
+
+LINE runs as Custom slot 3 with `PRESET=line`. Skip this step if you don't need LINE login.
+Full background is in [docs/src/guides/line.md](../docs/src/guides/line.md); the condensed
+deploy-time steps are:
+
+1. Open the [LINE Developers Console](https://developers.line.biz/console/), create or
+   open a Provider, then create a **LINE Login** channel
+2. Channel settings: enable **OpenID Connect**, set callback URLs:
+   - `http://localhost:3001/o2p/oauth2/line/authorized` (local development)
+   - `https://passkey-demo.ccmp.jp/o2p/oauth2/line/authorized` (production)
+3. OpenID Connect > scopes: `openid`, `profile`, and (if needed) `email`
+4. Email claim requires a separate manual application under **Email address permission**
+   (1-2 business days). Without approval, login fails with `OAuth2Error::Validation`
+5. Copy **Channel ID** (CLIENT_ID) and **Channel secret** (CLIENT_SECRET)
+
+```bash
+export OAUTH2_CUSTOM3_CLIENT_ID="your-line-channel-id"
+export OAUTH2_CUSTOM3_CLIENT_SECRET="your-line-channel-secret"
+# PRESET=line supplies DISPLAY_NAME / NAME / ICON_SLUG / brand color.
+# Issuer URL is fixed to https://access.line.me/ in env.cloud-run.yaml.
+```
+
 ### Step 3: Store secrets in Secret Manager
 
 ```bash
@@ -152,6 +175,10 @@ echo -n "$OAUTH2_CUSTOM1_CLIENT_SECRET" | gcloud secrets create OAUTH2_CUSTOM1_C
 echo -n "$OAUTH2_CUSTOM2_CLIENT_ID" | gcloud secrets create OAUTH2_CUSTOM2_CLIENT_ID --data-file=-
 echo -n "$OAUTH2_CUSTOM2_CLIENT_SECRET" | gcloud secrets create OAUTH2_CUSTOM2_CLIENT_SECRET --data-file=-
 
+# LINE secrets (first time only, if using LINE via CUSTOM3 slot)
+echo -n "$OAUTH2_CUSTOM3_CLIENT_ID" | gcloud secrets create OAUTH2_CUSTOM3_CLIENT_ID --data-file=-
+echo -n "$OAUTH2_CUSTOM3_CLIENT_SECRET" | gcloud secrets create OAUTH2_CUSTOM3_CLIENT_SECRET --data-file=-
+
 # Update secrets (add a new version to existing secrets)
 echo -n "$OAUTH2_GOOGLE_CLIENT_ID" | gcloud secrets versions add OAUTH2_GOOGLE_CLIENT_ID --data-file=-
 echo -n "$OAUTH2_GOOGLE_CLIENT_SECRET" | gcloud secrets versions add OAUTH2_GOOGLE_CLIENT_SECRET --data-file=-
@@ -164,6 +191,10 @@ echo -n "$OAUTH2_CUSTOM1_CLIENT_SECRET" | gcloud secrets versions add OAUTH2_CUS
 # Entra secret rotation (CUSTOM2 slot; Azure client secrets expire; max 24 months)
 echo -n "$OAUTH2_CUSTOM2_CLIENT_ID" | gcloud secrets versions add OAUTH2_CUSTOM2_CLIENT_ID --data-file=-
 echo -n "$OAUTH2_CUSTOM2_CLIENT_SECRET" | gcloud secrets versions add OAUTH2_CUSTOM2_CLIENT_SECRET --data-file=-
+
+# LINE secret rotation (CUSTOM3 slot)
+echo -n "$OAUTH2_CUSTOM3_CLIENT_ID" | gcloud secrets versions add OAUTH2_CUSTOM3_CLIENT_ID --data-file=-
+echo -n "$OAUTH2_CUSTOM3_CLIENT_SECRET" | gcloud secrets versions add OAUTH2_CUSTOM3_CLIENT_SECRET --data-file=-
 
 # Grant Cloud Run's default service account access to secrets
 PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')

--- a/dot.env.example
+++ b/dot.env.example
@@ -73,7 +73,8 @@ GENERIC_DATA_STORE_URL='postgresql://passkey:passkey@localhost:5432/passkey'
 #OAUTH2_CUSTOM1_ISSUER_URL='https://idp.example.com'
 #
 # ----- Preset (optional) -----
-# Set PRESET to one of 'auth0' | 'keycloak' | 'entra' to pre-populate
+# Set PRESET to one of 'auth0' | 'keycloak' | 'entra' | 'zitadel' |
+# 'okta' | 'authentik' | 'line' | 'apple' to pre-populate
 # DISPLAY_NAME, NAME, ICON_SLUG, BUTTON_COLOR, BUTTON_HOVER_COLOR and
 # any library-side quirks (e.g. login.live.com origin for Entra). Omit
 # PRESET for a bare Custom slot; then DISPLAY_NAME and NAME become

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -78,8 +78,8 @@ pub fn provider_info(name: &str) -> Option<ProviderInfo> {
 }
 
 /// Returns UI info for every currently enabled OAuth2 provider, in stable
-/// display order (Google first, then Auth0/Keycloak/Entra, then configured
-/// generic OIDC slots Custom1..Custom8).
+/// display order (Google first, then enabled generic OIDC slots
+/// Custom1..Custom8 in order).
 pub fn enabled_providers() -> Vec<ProviderInfo> {
     ProviderKind::ALL
         .iter()


### PR DESCRIPTION
  - CHANGELOG: fix reversed merge-priority wording (id_token wins, /userinfo is fallback)
  - CHANGELOG: correct identity-tier claim list (email, email_verified, preferred_username, hd; sub enforced upstream as IdMismatch)
  - dot.env.example: list all 8 presets in PRESET comment, not just 3
  - config.rs: enabled_providers rustdoc no longer references named Auth0/Keycloak/Entra (they are presets, not named tiers)
  - demo-live/DEPLOY.md: add Step 2c LINE credentials section and CUSTOM3 secret create/rotate commands (workflow already wires CUSTOM3 secrets)
  - File issue 20260511-0543 for validate_origin starts_with subdomain confusion (defense-in-depth, follow-up)

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>