### PR TITLE
  fix(oauth2): reject subdomain-confusion origins in validate_origin

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (10)
+### Open (9)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -17,14 +17,14 @@ This directory contains issue/task tracking files for the project.
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
-| `20260511-0543` | medium | low | [validate_origin starts_with subdomain confusion via Referer](open/20260511-0543-validate-origin-subdomain-confusion.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 
-### Completed (74)
+### Completed (75)
 
 | ID | Title |
 |----|-------|
+| `20260511-0543` | [validate_origin starts_with subdomain confusion via Referer](completed/20260511-0543-validate-origin-subdomain-confusion.md) |
 | `20260331-1517` | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](completed/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |
 | `20260420-0402` | [Admin unlink/delete fails in demo mode ("Invalid user ID")](completed/20260420-0402-admin-unlink-demo-mode.md) |
 | `20260423-0136` | [Consolidate idp/README.md into docs/](completed/20260423-0136-idp-readme-docs-consolidation.md) |

--- a/.claude/issues/completed/20260511-0543-validate-origin-subdomain-confusion.md
+++ b/.claude/issues/completed/20260511-0543-validate-origin-subdomain-confusion.md
@@ -7,12 +7,15 @@
 - [Proposed Fix](#proposed-fix)
 - [Related Files](#related-files)
 - [Timeline](#timeline)
+- [Resolution](#resolution)
 
 ## ID: 20260511-0543
 
 ## Created: 2026-05-11-05-43
 
-## Status: open
+## Closed: 2026-05-11-06-13
+
+## Status: completed
 
 ## Priority: medium
 
@@ -125,3 +128,46 @@ straightforward to test.
   v0.6.0 release prep is doc-accuracy fixes only; this is a code change
   that warrants its own PR with negative tests.
 - Reference: review-295.txt § "Findings worth fixing" item 1
+
+### 2026-05-11: Decision reversed -- fix in same release window
+
+- Re-evaluated: the attack surface widened in v0.6.0 with
+  `additional_allowed_origins` (Entra B2C `login.live.com`). Shipping
+  a security-focused release with a known origin-validation gap in the
+  same code paths the release expands is inconsistent.
+- `url` crate is already a direct workspace dependency (via reqwest
+  transitively, and used elsewhere in oauth2_passkey), so Option A
+  (structural URL parse + compare) has no dependency cost.
+- Decision: implement Option A in `fix/validate-origin-subdomain-confusion`
+  branched off dev (which already has the v0.6.0 release-prep merge).
+- Trade-off vs Option B (byte-after-prefix): Option A additionally
+  fixes case-insensitive host comparison and default-port normalization
+  (RFC 3986 compliance), at the cost of ~5 more lines.
+
+## Resolution
+
+Implemented via Option A on `fix/validate-origin-subdomain-confusion`:
+
+- Added private `origin_triple(&str) -> Option<(String, String, Option<u16>)>`
+  helper in `oauth2_passkey/src/oauth2/main/utils.rs` that parses a URL
+  string, lowercases scheme and host (RFC 3986 case-insensitivity), and
+  resolves the port via `Url::port_or_known_default()` (so `:443` for
+  https collapses to the implicit form).
+- `validate_origin` now pre-parses `auth_url` and every
+  `additional_allowed_origins` entry into triples, then matches the
+  incoming Origin / Referer candidate by structural equality. Subdomain-
+  confusion candidates such as `https://accounts.google.com.attacker.example`
+  no longer satisfy the check.
+- Seven negative / positive tests added in `utils/tests.rs`:
+  - subdomain confusion via Origin rejected
+  - subdomain confusion via Referer rejected
+  - subdomain confusion against `additional_allowed_origins` rejected
+  - case-insensitive host accepted (`https://EXAMPLE.com` vs
+    `https://example.com`)
+  - explicit default port `:443` accepted
+  - non-default port mismatch rejected
+  - unparseable Referer rejected
+- All 14 `validate_origin` tests pass (7 existing + 7 new). Workspace
+  test suite: 841 / 0.
+- CHANGELOG.md v0.6.0 § Security extended with an entry describing this
+  fix (release has not been tagged yet at the time of merge).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - RUSTSEC-2026-0098: name constraints for URI names incorrectly accepted
   - RUSTSEC-2026-0099: name constraints accepted for wildcard certs
   - RUSTSEC-2026-0104: reachable panic in CRL parsing
+- `validate_origin` now compares the incoming Origin / Referer
+  structurally (scheme + host + port via `url::Url`) instead of using
+  a raw `starts_with` prefix match. Closes a subdomain-confusion gap
+  where e.g. `https://accounts.google.com.attacker.example` satisfied
+  the prefix check against `https://accounts.google.com`. The same
+  defense applies to `additional_allowed_origins` (e.g. `login.live.com`
+  for the Entra personal-accounts flow). Case-insensitive host and
+  default-port (`:443` / `:80`) normalization are now also honored
 
 ### Fixed
 

--- a/oauth2_passkey/src/oauth2/main/utils.rs
+++ b/oauth2_passkey/src/oauth2/main/utils.rs
@@ -103,6 +103,19 @@ pub(super) async fn verify_and_consume_nonce(
     Ok(())
 }
 
+/// Parse a URL string into a `(scheme, host, port)` triple for origin
+/// comparison. Scheme and host are lowercased per RFC 3986; port is the
+/// explicit port or the scheme's default (443 for https, 80 for http).
+/// Returns `None` if the input does not parse as a URL or has no host.
+fn origin_triple(s: &str) -> Option<(String, String, Option<u16>)> {
+    let u = Url::parse(s).ok()?;
+    Some((
+        u.scheme().to_ascii_lowercase(),
+        u.host_str()?.to_ascii_lowercase(),
+        u.port_or_known_default(),
+    ))
+}
+
 pub(crate) async fn validate_origin(
     headers: &HeaderMap,
     auth_url: &str,
@@ -116,6 +129,16 @@ pub(crate) async fn validate_origin(
         .map_or("".to_string(), |p| format!(":{p}"));
     let expected_origin = format!("{scheme}://{host}{port}");
 
+    // Pre-parse the expected origin and each additional allowed origin into
+    // (scheme, host, port) triples for structural comparison. This rejects
+    // subdomain-confusion candidates like
+    // "https://accounts.google.com.attacker.com" against
+    // "https://accounts.google.com" that a raw `starts_with` would accept.
+    let allowed_triples: Vec<_> = std::iter::once(auth_url)
+        .chain(additional_allowed_origins.iter().map(String::as_str))
+        .filter_map(origin_triple)
+        .collect();
+
     // Browsers send `Origin: null` for cross-origin form_post redirects (e.g. Auth0).
     // Treat the literal string "null" the same as absent and fall back to Referer.
     let origin = {
@@ -127,10 +150,7 @@ pub(crate) async fn validate_origin(
     };
 
     let matches = |candidate: &str| {
-        candidate.starts_with(&expected_origin)
-            || additional_allowed_origins
-                .iter()
-                .any(|allowed| candidate.starts_with(allowed))
+        origin_triple(candidate).is_some_and(|cand| allowed_triples.contains(&cand))
     };
 
     match origin {

--- a/oauth2_passkey/src/oauth2/main/utils.rs
+++ b/oauth2_passkey/src/oauth2/main/utils.rs
@@ -121,6 +121,10 @@ pub(crate) async fn validate_origin(
     auth_url: &str,
     additional_allowed_origins: &[String],
 ) -> Result<(), OAuth2Error> {
+    // `expected_origin` is for error messages and logging only. It preserves
+    // operator-facing input (no `:443` / `:80` injection) so messages look
+    // like the configured value. Origin matching itself uses the structural
+    // comparison in `allowed_triples` below.
     let parsed_url = Url::parse(auth_url).expect("Invalid URL");
     let scheme = parsed_url.scheme();
     let host = parsed_url.host_str().unwrap_or_default();

--- a/oauth2_passkey/src/oauth2/main/utils/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/utils/tests.rs
@@ -233,6 +233,114 @@ async fn test_validate_origin_null_without_referer() {
     }
 }
 
+/// Subdomain-confusion attacker host must not match expected origin.
+///
+/// `https://example.com.attacker.example/...` previously satisfied
+/// `starts_with("https://example.com")` because the next character was a
+/// valid host-segment byte. Structural origin comparison rejects it.
+#[tokio::test]
+async fn test_validate_origin_rejects_subdomain_confusion() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Origin",
+        HeaderValue::from_static("https://example.com.attacker.example"),
+    );
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(
+        result.is_err(),
+        "subdomain-confusion Origin must be rejected"
+    );
+}
+
+/// Same defense, exercised via the Referer fallback path.
+#[tokio::test]
+async fn test_validate_origin_rejects_subdomain_confusion_via_referer() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Referer",
+        HeaderValue::from_static("https://example.com.attacker.example/path"),
+    );
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(
+        result.is_err(),
+        "subdomain-confusion Referer must be rejected"
+    );
+}
+
+/// `additional_allowed_origins` entries must also resist subdomain confusion.
+/// Mirrors the Entra preset path where `https://login.live.com` is registered
+/// as an extra allowed origin.
+#[tokio::test]
+async fn test_validate_origin_rejects_subdomain_confusion_in_additional() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Origin",
+        HeaderValue::from_static("https://login.live.com.attacker.example"),
+    );
+
+    let result = validate_origin(
+        &headers,
+        "https://example.com/oauth2/callback",
+        &["https://login.live.com".to_string()],
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "subdomain confusion against additional_allowed_origins must be rejected"
+    );
+}
+
+/// RFC 3986: scheme and host are case-insensitive. Different casing must match.
+#[tokio::test]
+async fn test_validate_origin_case_insensitive_host() {
+    let mut headers = HeaderMap::new();
+    headers.insert("Origin", HeaderValue::from_static("https://EXAMPLE.com"));
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(result.is_ok(), "case-insensitive host must match");
+}
+
+/// Explicit default port must match the implicit form (https:443).
+#[tokio::test]
+async fn test_validate_origin_default_port_normalization() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Origin",
+        HeaderValue::from_static("https://example.com:443"),
+    );
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(
+        result.is_ok(),
+        "explicit default port :443 must match implicit form"
+    );
+}
+
+/// Non-default port mismatch must be rejected.
+#[tokio::test]
+async fn test_validate_origin_different_port_rejected() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Origin",
+        HeaderValue::from_static("https://example.com:8443"),
+    );
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(result.is_err(), "different port must not match");
+}
+
+/// Malformed Referer must be rejected, not treated as a wildcard match.
+#[tokio::test]
+async fn test_validate_origin_invalid_url_rejected() {
+    let mut headers = HeaderMap::new();
+    headers.insert("Referer", HeaderValue::from_static("not-a-url"));
+
+    let result = validate_origin(&headers, "https://example.com/oauth2/callback", &[]).await;
+    assert!(result.is_err(), "unparseable candidate must be rejected");
+}
+
 /// Tests for validate_origin with mismatched origin
 ///
 /// This test verifies that `validate_origin` correctly validates an origin

--- a/oauth2_passkey/src/oauth2/main/utils/tests.rs
+++ b/oauth2_passkey/src/oauth2/main/utils/tests.rs
@@ -341,6 +341,46 @@ async fn test_validate_origin_invalid_url_rejected() {
     assert!(result.is_err(), "unparseable candidate must be rejected");
 }
 
+/// An unparseable entry in `additional_allowed_origins` must be silently
+/// dropped (fail-closed): it neither matches anything nor short-circuits
+/// the check, and a sibling valid entry still works.
+#[tokio::test]
+async fn test_validate_origin_unparseable_additional_origin_dropped() {
+    let mut headers = HeaderMap::new();
+    headers.insert("Origin", HeaderValue::from_static("https://login.live.com"));
+
+    let result = validate_origin(
+        &headers,
+        "https://example.com/oauth2/callback",
+        &[
+            "not-a-valid-url".to_string(),
+            "https://login.live.com".to_string(),
+        ],
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "valid sibling allowed origin must still match when an unparseable entry is present"
+    );
+
+    // And the unparseable entry on its own does not authorize anything.
+    let mut headers2 = HeaderMap::new();
+    headers2.insert(
+        "Origin",
+        HeaderValue::from_static("https://attacker.example"),
+    );
+    let result2 = validate_origin(
+        &headers2,
+        "https://example.com/oauth2/callback",
+        &["not-a-valid-url".to_string()],
+    )
+    .await;
+    assert!(
+        result2.is_err(),
+        "unparseable additional_allowed_origins entry must not authorize anything"
+    );
+}
+
 /// Tests for validate_origin with mismatched origin
 ///
 /// This test verifies that `validate_origin` correctly validates an origin


### PR DESCRIPTION
  Replace the raw `starts_with` prefix match with structural origin
  comparison (scheme + host + port) via `url::Url`. The previous
  implementation accepted candidates such as
  `https://accounts.google.com.attacker.example` against an expected
  origin of `https://accounts.google.com` because the next character
  in the candidate was a valid host-segment byte. The same defense
  applies to entries in `additional_allowed_origins` (e.g.
  `https://login.live.com` for the Entra personal-accounts flow,
  which v0.6.0 introduced).

  Side effects of moving to structural comparison:
  - RFC 3986 case-insensitive host comparison
  - Default-port normalization (`:443` matches the implicit form)

  Tests: 7 new (3 subdomain-confusion rejections, case-insensitivity,
  explicit-default-port, non-default-port rejection, malformed URL
  rejection). Existing tests unchanged.

  Closes 20260511-0543.

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>