### PR TITLE
  docs(archived): correct status labeling for design proposals (close…

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (13)
+### Open (12)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -18,16 +18,16 @@ This directory contains issue/task tracking files for the project.
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
 | `20260512-0350` | low | small | [Use constant-time comparison in verify_page_session_token](open/20260512-0350-constant-time-page-session-token.md) |
-| `20260512-0351` | low | small | [Correct status labeling for archived design proposals](open/20260512-0351-archived-design-proposals-status-labeling.md) |
 | `20260512-0457` | low | small | [Standardize Rust code block markers in mdBook docs to `rust,ignore`](open/20260512-0457-standardize-rust-block-markers.md) |
 | `20260226-2018` | low | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 
-### Completed (75)
+### Completed (76)
 
 | ID | Title |
 |----|-------|
+| `20260512-0351` | [Correct status labeling for archived design proposals](completed/20260512-0351-archived-design-proposals-status-labeling.md) |
 | `20260511-0543` | [validate_origin starts_with subdomain confusion via Referer](completed/20260511-0543-validate-origin-subdomain-confusion.md) |
 | `20260331-1517` | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](completed/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |
 | `20260420-0402` | [Admin unlink/delete fails in demo mode ("Invalid user ID")](completed/20260420-0402-admin-unlink-demo-mode.md) |

--- a/.claude/issues/completed/20260512-0351-archived-design-proposals-status-labeling.md
+++ b/.claude/issues/completed/20260512-0351-archived-design-proposals-status-labeling.md
@@ -4,8 +4,8 @@
 
 - ID: 20260512-0351
 - Created: 2026-05-12-03-51
-- Closed:
-- Status: open
+- Closed: 2026-05-12-05-13
+- Status: completed
 - Priority: low
 - Difficulty: small
 - Related Issues:
@@ -101,10 +101,10 @@ Prepend a status notice at the top of
 
 ### Implementation Tasks
 
-- [ ] Restructure `archived/README.md` Design Proposals into "Implemented" and "Superseded / Not Implemented"
-- [ ] Spot-check that each remaining "Implemented" entry has corresponding implementation in code; reclassify any that don't
-- [ ] Prepend Status notice to `oauth2-account-linking-api-simplification.md`
-- [ ] If the mdBook build is part of CI, verify it still passes
+- [x] Restructure `archived/README.md` Design Proposals into "Implemented" and "Superseded / Not Implemented"
+- [x] Spot-check that each remaining "Implemented" entry has corresponding implementation in code; reclassify any that don't
+- [x] Prepend Status notice to `oauth2-account-linking-api-simplification.md`
+- [x] If the mdBook build is part of CI, verify it still passes
 
 ### Verification
 
@@ -112,3 +112,34 @@ Prepend a status notice at the top of
 - Each listed proposal's status accurately reflects code reality
 
 ## Resolution
+
+Branch: `chore/archived-proposals-labeling`.
+
+Spot-check confirmed all 6 remaining proposals listed under
+"Implemented" are in fact implemented (evidence per Latest Plan):
+
+- `cache-expiration-system-simplification` — TTL/expiration logic in
+  `oauth2_passkey/src/storage/types.rs` and
+  `cache_store/{memory,redis}.rs`
+- `implementing-tracing` — `tracing::` used across core
+  (`utils.rs`, `session/config.rs`, `oauth2/main/oidc.rs`, etc.)
+- `integration-testing-plan` — `oauth2_passkey_axum/tests/integration/`
+  (`api_client_flows.rs`, `combined_flows.rs`, `oauth2_flows.rs`,
+  `passkey_flows.rs`)
+- `testing-oidc-discovery` — `oauth2_passkey/src/oauth2/discovery/tests.rs`
+- `TestKeyPairGeneration` — `oauth2_passkey/src/coordination/passkey/tests.rs`
+- `type-safe-validation` — newtypes (`UserId`, `ProviderName`, etc.)
+  exposed in `oauth2_passkey/src/lib.rs`
+
+Changes landed:
+
+1. `docs/src/archived/README.md` — Design Proposals section split
+   into "Implemented" (6 entries) and "Superseded / Not Implemented"
+   (1 entry, `oauth2-account-linking-api-simplification.md` with
+   inline pointer to issues `20260226-2018` and `20260512-0335`).
+2. `docs/src/archived/design-proposals/oauth2-account-linking-api-simplification.md`
+   — Status notice blockquote prepended right after the H1, citing
+   the parent issue Timeline entry and the architectural
+   reconsideration tracked under the child issue.
+
+`mdbook build docs` clean.

--- a/docs/src/archived/README.md
+++ b/docs/src/archived/README.md
@@ -25,12 +25,15 @@ Historical test quality assessments from June 2025:
 
 ## Design Proposals
 
-Implemented design documents and proposals:
+### Implemented
 
 - [cache-expiration-system-simplification.md](design-proposals/cache-expiration-system-simplification.md)
 - [implementing-tracing.md](design-proposals/implementing-tracing.md)
 - [integration-testing-plan.md](design-proposals/integration-testing-plan.md)
-- [oauth2-account-linking-api-simplification.md](design-proposals/oauth2-account-linking-api-simplification.md)
 - [testing-oidc-discovery.md](design-proposals/testing-oidc-discovery.md)
 - [TestKeyPairGeneration.md](design-proposals/TestKeyPairGeneration.md)
 - [type-safe-validation.md](design-proposals/type-safe-validation.md)
+
+### Superseded / Not Implemented
+
+- [oauth2-account-linking-api-simplification.md](design-proposals/oauth2-account-linking-api-simplification.md) — see issues `20260226-2018` and `20260512-0335` for current status

--- a/docs/src/archived/design-proposals/oauth2-account-linking-api-simplification.md
+++ b/docs/src/archived/design-proposals/oauth2-account-linking-api-simplification.md
@@ -1,5 +1,13 @@
 # OAuth2 Account Linking API Simplification
 
+> **Status: Superseded.** The specific API recommendations in this
+> document (one-function `.await`, provider-specific traits, builder
+> pattern, middleware) were critiqued and rejected in issue
+> `20260226-2018` Timeline entry 2026-05-12T02:46. The architectural
+> question this proposal tried to address is being reconsidered
+> under issue `20260512-0335` (POST-based linking initiation, which
+> would eliminate the `page_session_token` concept entirely).
+
 ## Problem Statement
 
 The current OAuth2 account linking implementation creates a significant barrier to adoption due to its complexity. Users must understand and coordinate multiple concepts and API calls to accomplish what should be a simple operation.


### PR DESCRIPTION
…s 20260512-0351)

  - Split archived/README.md Design Proposals into "Implemented" and "Superseded / Not Implemented" subsections (was misleadingly labeled "Implemented design documents and proposals" for all entries)
  - Move oauth2-account-linking-api-simplification.md to the Superseded section with a pointer to issues 20260226-2018 and 20260512-0335
  - Prepend Status notice blockquote to the proposal itself, citing the Timeline critique and the architectural reconsideration under the child issue
  - Spot-checked remaining 6 entries — all confirmed implemented (cache expiration, tracing, integration tests, OIDC discovery tests, test key pair generation, type-safe newtypes)
  - Close issue 20260512-0351 (move to completed/, update tracker README)