### PR TITLE
  fix(session): use constant-time comparison in verify_page_session_t…

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (12)
+### Open (11)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -17,16 +17,16 @@ This directory contains issue/task tracking files for the project.
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
-| `20260512-0350` | low | small | [Use constant-time comparison in verify_page_session_token](open/20260512-0350-constant-time-page-session-token.md) |
 | `20260512-0457` | low | small | [Standardize Rust code block markers in mdBook docs to `rust,ignore`](open/20260512-0457-standardize-rust-block-markers.md) |
 | `20260226-2018` | low | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 
-### Completed (76)
+### Completed (77)
 
 | ID | Title |
 |----|-------|
+| `20260512-0350` | [Use constant-time comparison in verify_page_session_token](completed/20260512-0350-constant-time-page-session-token.md) |
 | `20260512-0351` | [Correct status labeling for archived design proposals](completed/20260512-0351-archived-design-proposals-status-labeling.md) |
 | `20260511-0543` | [validate_origin starts_with subdomain confusion via Referer](completed/20260511-0543-validate-origin-subdomain-confusion.md) |
 | `20260331-1517` | [PASSKEY_AUTHENTICATOR_ATTACHMENT=none sends non-standard string instead of omitting field](completed/20260331-1517-passkey-authenticator-attachment-none-serialization.md) |

--- a/.claude/issues/completed/20260512-0350-constant-time-page-session-token.md
+++ b/.claude/issues/completed/20260512-0350-constant-time-page-session-token.md
@@ -4,8 +4,8 @@
 
 - ID: 20260512-0350
 - Created: 2026-05-12-03-50
-- Closed:
-- Status: open
+- Closed: 2026-05-12-05-22
+- Status: completed
 - Priority: low
 - Difficulty: small
 - Related Issues:
@@ -77,10 +77,10 @@ if context_bytes.len() != expected_bytes.len()
 
 ### Implementation Tasks
 
-- [ ] Replace `!=` with `subtle::ConstantTimeEq` per implementation sketch
-- [ ] Verify existing `page_session_token` unit tests pass
-- [ ] Run `cargo fmt --all` and `cargo clippy --all-targets --all-features`
-- [ ] Run full workspace test suite
+- [x] Replace `!=` with `subtle::ConstantTimeEq` per implementation sketch
+- [x] Verify existing `page_session_token` unit tests pass
+- [x] Run `cargo fmt --all` and `cargo clippy --all-targets --all-features`
+- [x] Run full workspace test suite
 
 ### Verification
 
@@ -89,3 +89,33 @@ if context_bytes.len() != expected_bytes.len()
 - Existing tests `test_verify_page_session_token_success`, `_invalid_token`, `_missing_token`, `_missing_session` continue to pass
 
 ## Resolution
+
+Branch: `chore/constant-time-page-session-token`.
+
+`oauth2_passkey/src/session/main/page_session_token.rs:107`
+replaced with constant-time comparison. The final form is simpler
+than the implementation sketch in Latest Plan — `subtle::ConstantTimeEq`
+on `&[u8]` already short-circuits on length mismatch, so no
+explicit length check is needed:
+
+```rust
+let expected = generate_page_session_token(&stored_session.csrf_token);
+if !bool::from(context.as_bytes().ct_eq(expected.as_bytes())) {
+    tracing::error!("Page session token does not match session user");
+    return Err(SessionError::PageSessionToken(
+        "Page session token does not match session user".to_string(),
+    ));
+}
+```
+
+`subtle` was already a workspace dependency
+(`oauth2_passkey/Cargo.toml:37`); only the import line was added.
+
+Verification:
+
+- `cargo clippy --all-targets --all-features -p oauth2-passkey` clean
+- `cargo test --manifest-path oauth2_passkey/Cargo.toml` — all tests pass,
+  including the 7 `page_session_token` tests
+- `cargo test --manifest-path oauth2_passkey_axum/Cargo.toml --all-features`
+  — all tests pass
+- `cargo fmt --all` clean

--- a/oauth2_passkey/src/session/main/page_session_token.rs
+++ b/oauth2_passkey/src/session/main/page_session_token.rs
@@ -8,6 +8,7 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use hmac::{Hmac, KeyInit, Mac};
 use http::HeaderMap;
 use sha2::Sha256;
+use subtle::ConstantTimeEq;
 
 use crate::{
     session::{config::AUTH_SERVER_SECRET, errors::SessionError, types::StoredSession},
@@ -104,7 +105,8 @@ pub async fn verify_page_session_token(
 
     match page_session_token {
         Some(context) => {
-            if context.as_str() != generate_page_session_token(&stored_session.csrf_token) {
+            let expected = generate_page_session_token(&stored_session.csrf_token);
+            if !bool::from(context.as_bytes().ct_eq(expected.as_bytes())) {
                 tracing::error!("Page session token does not match session user");
                 return Err(SessionError::PageSessionToken(
                     "Page session token does not match session user".to_string(),


### PR DESCRIPTION
…oken (closes 20260512-0350)

  - Replace plain `!=` with `subtle::ConstantTimeEq` for HMAC comparison in verify_page_session_token
  - Matches the project's stated security policy in docs/src/security/csrf.md (constant-time comparison mandated for CSRF-class tokens)
  - Subtle's ct_eq on &[u8] already short-circuits on length mismatch, so no explicit length check is needed
  - Subtle was already a workspace dependency (oauth2_passkey/Cargo.toml:37); only the import was added
  - All 7 page_session_token unit tests pass; cargo clippy clean
  - Close issue 20260512-0350 (move to completed/, update tracker README)