### PR TITLE
  chore(issues): close 20260226-2018 as wontfix

### DIFF
--- a/.claude/issues/README.md
+++ b/.claude/issues/README.md
@@ -6,7 +6,7 @@ This directory contains issue/task tracking files for the project.
 
 <!-- AUTO-UPDATED: Do not edit manually. Updated by /issue command. -->
 
-### Open (9)
+### Open (8)
 
 | ID | Priority | Difficulty | Title |
 |----|----------|------------|-------|
@@ -16,7 +16,6 @@ This directory contains issue/task tracking files for the project.
 | `2026-02-08-02` | medium | medium | [Login History DB Spam Risk from Brute-Force Attacks](open/2026-02-08-login-history-db-spam.md) |
 | `20260226-2024` | medium | medium | [Rate Limiting](open/20260226-2024-rate-limiting.md) |
 | `20260321-1245` | medium | medium | [Multi-Database Integration Tests](open/20260321-1245-multi-db-integration-tests.md) |
-| `20260226-2018` | low | medium | [Simplify OAuth2 Account Linking API](open/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `2026-01-24-01` | low | medium | [Documentation Improvement Planning](open/2026-01-24-docs-improvement-planning.md) |
 | `20260323-1338` | low | medium | [Test Coverage Improvement for Non-DB Code Paths](open/20260323-1338-test-coverage-improvement.md) |
 
@@ -103,10 +102,11 @@ This directory contains issue/task tracking files for the project.
 | `2026-01-30-09` | [Cross-Origin Same-Site Demo (Pattern 2)](completed/2026-01-30-cross-origin-same-site-demo.md) |
 | `2026-01-31-02` | [Remove HTTPS Support from Demo Apps](completed/2026-01-31-demo-remove-https.md) |
 
-### Wontfix (6)
+### Wontfix (7)
 
 | ID | Title |
 |----|-------|
+| `20260226-2018` | [Simplify OAuth2 Account Linking API](wontfix/20260226-2018-simplify-oauth2-account-linking-api.md) |
 | `20260512-0335` | [POST-based OAuth2 account linking initiation (Alt 5B validation)](wontfix/20260512-0335-post-based-oauth2-linking-validation.md) |
 | `20260420-1458` | [Add GitHub as OAuth2 Provider (non-OIDC)](wontfix/20260420-1458-add-github-provider.md) |
 | `20260226-2023` | [Authentication Method Tracking in Session](wontfix/20260226-2023-auth-method-tracking-in-session.md) |

--- a/.claude/issues/wontfix/20260226-2018-simplify-oauth2-account-linking-api.md
+++ b/.claude/issues/wontfix/20260226-2018-simplify-oauth2-account-linking-api.md
@@ -4,12 +4,12 @@
 
 - ID: 20260226-2018
 - Created: 2026-02-26-20-18
-- Closed:
-- Status: open
+- Closed: 2026-05-12-15-39
+- Status: wontfix
 - Priority: low
 - Difficulty: medium
 - Related Issues:
-  - `20260512-0335` POST-based OAuth2 account linking initiation (Alt 5B validation) (child — determines this issue's outcome)
+  - `20260512-0335` POST-based OAuth2 account linking initiation (Alt 5B validation) (child — closed as wontfix 2026-05-12, determined this issue's outcome)
 
 ## Problem
 
@@ -329,6 +329,73 @@ subsection. This work was tangential to the parent issue's scope
 The Always-section scope of this parent issue is unchanged; this
 entry records the side-effect for traceability.
 
+### 2026-05-12T15:39 — Decision: close as wontfix
+
+Closing the issue.
+
+Child `20260512-0335` (Alt 5B / POST-based linking validation)
+landed at commit `ca62953` end-to-end (env var
+`OAUTH2_LINKING_MODE`, `POST /oauth2/{provider}`,
+`POST /oauth2/select`, `select_provider.j2` branch,
+`oauth2.linkAccountPost` / `oauth2.startLinkingViaForm` JS API)
+and was then reverted at `f13d247` as wontfix. The negative
+result is preserved in dev's git history and the child issue's
+Timeline (T03:35 through T15:26). The conclusion was that POST
+mode delivers no meaningful value over GET — same security
+coverage, page_session_token still needed for the GET default,
+zero user-visible change at the built-in /user/account page,
+permanent two-path maintenance cost.
+
+That outcome also undermines this parent issue's framing. The
+parent originally claimed (per archived design proposal) that
+OAuth2 account linking required ~50+ lines of integration code
+and was "a key usability barrier for library adoption". The
+2026-05-12T02:46 re-evaluation entry already established that
+the 50+ figure came from an integration-test helper, not real
+application code: with the built-in `/user/account` page, a
+library user writes 0 lines; with a custom UI, ~3 lines. Alt
+5B was the strongest concrete remediation candidate this issue
+produced. Its failure isn't a setback for "simplify OAuth2
+linking" — it's evidence that there's no real complexity to
+simplify.
+
+The Latest Plan's "Always" section (docs restructure of
+`page-session.md` → `oauth2-linking-protection.md`) was
+already executed and merged via PR #341. The "If Alt 5B is
+no-go" fallback was a small free-function helper
+(`oauth2_link_url`) plus a custom-UI guide chapter; per the
+analysis above the helper saves ~1 line per custom-UI handler,
+which doesn't justify the public-API surface area, and the
+guide is something to write only if there's documented user
+demand. Neither will be acted on by this issue.
+
+What remains unaddressed in the broader "OAuth2 account
+linking" space — if any reader reaches this Timeline looking
+for follow-up work:
+
+- **No outstanding bugs.** Current GET-based flow is
+  production-tested via the demo apps and integration tests.
+- **No outstanding security issues.** GET-mode threat coverage
+  is documented in `docs/src/security/oauth2-linking-protection.md`
+  (the doc that this issue's "Always" section produced); Alt
+  5B was the alternative-architecture investigation and is now
+  closed out.
+- **No outstanding ergonomics issues.** The 3-line custom-UI
+  case is well within library conventions. If a future
+  contributor finds the friction worth removing they can open
+  a fresh issue with the concrete use case.
+
+Closing as `wontfix` rather than `completed` because nothing in
+the original Implementation Tasks list shipped on this issue
+specifically — Always-section docs work landed via the same
+branch but is attributed there; the conditional fallback is
+declined; Alt 5B (the actual exploration this issue spawned)
+went to its own issue and was closed wontfix.
+
+The Latest Plan below is left unchanged as a historical
+artifact of the design exploration. The authoritative outcome
+is in this Timeline entry and the Resolution section.
+
 ## Latest Plan
 
 Scope is split into work that proceeds regardless of Alt 5B's
@@ -446,3 +513,42 @@ Conditional on no-go fallback:
   against `demo-both`.
 
 ## Resolution
+
+Closed as `wontfix`. Full reasoning in Timeline entry
+2026-05-12T15:39.
+
+In short: the design exploration that this issue spawned
+concluded that OAuth2 account linking is not in fact complex
+enough to require simplification. Child issue `20260512-0335`
+prototyped the strongest concrete remediation candidate
+(POST-based linking, Alt 5B); it worked but added cost without
+net benefit and was reverted (commit `f13d247`, history
+preserved). The fallback "small helper + docs" path was also
+declined for the same reason — there's no observed friction
+that justifies expanding the public API.
+
+What did land from this issue's branch family:
+
+- Docs restructure: `page-session.md` was renamed to
+  `oauth2-linking-protection.md` with a two-phase conceptual
+  overview moved to the top (PR #341).
+- Sibling passkey doc: `passkey-registration-protection.md`
+  was authored as the parallel for passkey registration's
+  session-boundary protection (separate session, committed
+  via PR #341's branch).
+- Side findings extracted to their own issues:
+  - `20260512-0350` constant-time comparison fix (completed)
+  - `20260512-0351` archived-proposals status labeling
+    (completed)
+  - `20260512-0457` rust,ignore standardization across docs
+    (completed)
+- The archived design proposal itself
+  (`oauth2-account-linking-api-simplification.md`) was moved
+  to the "Superseded / Not Implemented" section of
+  `docs/src/archived/README.md` and got a Status notice
+  pointing at this issue and `20260512-0335`.
+
+Net effect on the codebase: pure improvements (docs hygiene,
+security policy compliance, design-proposal labeling
+correctness) plus a documented negative result. No
+user-facing API change.


### PR DESCRIPTION
  Parent issue "Simplify OAuth2 Account Linking API" closes following the wontfix decision on its child issue 20260512-0335 (Alt 5B / POST-based linking).

  - Child outcome: POST-based linking prototyped end-to-end, evaluated, reverted. Negative result preserved in dev's git history at commits ca62953 (impl) + f13d247 (revert).
  - Parent framing disproven: the archived design proposal's "50+ lines of integration code" figure came from an integration-test helper, not real application code. Built-in /user/account page requires 0 user-code lines; a custom UI is ~3 lines. There is no real complexity to simplify.
  - "If no-go" fallback (oauth2_link_url helper + custom-UI guide chapter) declined for the same reason — no observed friction worth the public-API surface area.

  Net effect on the codebase from this issue's branch family:
  - Docs restructure (page-session.md -> oauth2-linking-protection.md with two-phase overview)
  - Sibling passkey doc (passkey-registration-protection.md)
  - Side findings closed via their own issues (20260512-0350, 20260512-0351, 20260512-0457)
  - Archived design proposal labeled "Superseded / Not Implemented" with pointer to this issue and 20260512-0335

  Latest Plan in the issue file left as historical artifact; authoritative outcome captured in Timeline entry 2026-05-12T15:39 and the Resolution section.

  Issue file moved open/ -> wontfix/, tracker README updated (Open 9->8, Wontfix 6->7).